### PR TITLE
Require PSA from PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,6 @@ The `auth_backends` package can be installed from PyPI using pip::
 
     pip install edx-auth-backends
 
-Use of `auth_backends` requires a specific version of `Python Social Auth <https://github.com/omab/python-social-auth>`_ which,
-as of Friday, February 20, has not been released on PyPI. Please install it from GitHub by running::
-    
-    pip install git+https://github.com/edx/python-social-auth.git@pyjwt-fix#egg=python-social-auth
-
 Overview
 --------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,10 @@
 Django==1.7.4                  # BSD License
-
-# PSA package on PyPI hasn't been updated to include a fix for a breaking change in PyJWT
-# python-social-auth==0.2.1    # BSD
-git+https://github.com/edx/python-social-auth.git@pyjwt-fix#egg=python-social-auth
+python-social-auth==0.2.2      # BSD
 
 # For running tests
 django-dynamic-fixture==1.8.1  # MIT
 django-nose==1.3
-httpretty==0.6.5
-unittest2==0.5.1
+httpretty==0.8.3
+unittest2==0.8.0
 coverage==3.7.1
 mock==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         'Django>=1.7',
+        'python-social-auth>=0.2.2',
     ],
 )


### PR DESCRIPTION
The released version of python-social-auth was just updated to 0.2.2. This PR updates the dependencies for the edx-auth-backends package to include the new version.

@stephensanchez, when you have a moment, can I get a quick thumb? I'll release a new version of the package on PyPI once this is in.