### PR TITLE
Upgrade PSA to 0.2.3

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,15 @@
 History
 =======
 
+0.1.3 (2015-03-31)
+------------------
+
+- Update required version of Python Social Auth to 0.2.3.
+
 0.1.2 (2015-02-23)
 ------------------
 
-- Update required version of Python Social Auth.
+- Update required version of Python Social Auth to 0.2.2.
 
 0.1.1 (2015-02-20)
 ------------------

--- a/auth_backends/_version.py
+++ b/auth_backends/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.1.2'  # pragma: no cover
+__version__ = '0.1.3'  # pragma: no cover

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.7.4                  # BSD License
-python-social-auth==0.2.2      # BSD
+python-social-auth==0.2.3      # BSD
 
 # For running tests
 django-dynamic-fixture==1.8.1  # MIT

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         'Django>=1.7',
-        'python-social-auth>=0.2.2',
+        'python-social-auth>=0.2.3',
     ],
 )


### PR DESCRIPTION
Upgrading PSA to 0.2.3 fixes a PyJWT dependency conflict when using auth-backends with other projects which have upgraded to PyJWT >= 1.0.0. I'll tag and create a new release of auth-backends once this lands.

@clintonb or @nasthagiri 

@feanil FYI