### PR TITLE
Moved logout view tests to mixin

### DIFF
--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '0.3.0'  # pragma: no cover
+__version__ = '0.3.1'  # pragma: no cover

--- a/auth_backends/tests/mixins.py
+++ b/auth_backends/tests/mixins.py
@@ -1,0 +1,51 @@
+""" Test mixins. """
+
+from django.contrib.auth import get_user, get_user_model
+from django.core.urlresolvers import reverse
+
+User = get_user_model()
+
+
+class LogoutViewTestMixin(object):
+    """ Mixin for tests of the LogoutRedirectBaseView children. """
+
+    def get_logout_url(self):
+        """ Returns the URL of the logout view. """
+        return reverse('logout')
+
+    def get_redirect_url(self):
+        """ Returns the URL to which the user should be redirected after logout. """
+        raise NotImplementedError  # pragma: no cover
+
+    def assert_authentication_status(self, is_authenticated):
+        """ Verifies the authentication status of the user attached to the test client. """
+        user = get_user(self.client)
+        self.assertEqual(user.is_authenticated(), is_authenticated)
+
+    def test_redirect_url(self):
+        """ Verify the view redirects to the correct URL. """
+        response = self.client.get(self.get_logout_url())
+        self.assertRedirects(response, self.get_redirect_url(), fetch_redirect_response=False)
+
+    def test_x_frame_options_header(self):
+        """ Verify no X-Frame-Options header is set in the resposne. """
+        response = self.client.get(self.get_logout_url())
+        self.assertNotIn('X-Frame-Options', response)
+
+    def test_logout(self):
+        """ Verify the user is logged out of the current session. """
+        self.client.logout()
+        self.assert_authentication_status(False)
+
+        password = 'test'
+        user = User.objects.create_user('test', password=password)
+        self.client.login(username=user.username, password=password)
+        self.assert_authentication_status(True)
+
+        self.client.get(self.get_logout_url())
+        self.assert_authentication_status(False)
+
+    def test_no_redirect(self):
+        """ Verify the view does not redirect if the no_redirect querystring parameter is set. """
+        response = self.client.get(self.get_logout_url(), {'no_redirect': 1})
+        self.assertEqual(response.status_code, 200)

--- a/auth_backends/tests/test_views.py
+++ b/auth_backends/tests/test_views.py
@@ -1,14 +1,12 @@
 """ Tests for the views module. """
 
 from django.conf.urls import url
-from django.contrib.auth import get_user_model, get_user
-from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings
 
+from auth_backends.tests.mixins import LogoutViewTestMixin
 from auth_backends.views import LogoutRedirectBaseView
 
 LOGOUT_REDIRECT_URL = 'https://www.example.com/logout/'
-User = get_user_model()
 
 urlpatterns = [
     url(r'^logout/$', LogoutRedirectBaseView.as_view(url=LOGOUT_REDIRECT_URL), name='logout'),
@@ -16,38 +14,8 @@ urlpatterns = [
 
 
 @override_settings(ROOT_URLCONF=__name__)
-class LogoutRedirectBaseViewTests(TestCase):
+class LogoutRedirectBaseViewTests(LogoutViewTestMixin, TestCase):
     """ Tests for LogoutRedirectBaseView. """
 
-    def assert_authentication_status(self, is_authenticated):
-        """ Verifies the authentication status of the user attached to the test client. """
-        user = get_user(self.client)
-        self.assertEqual(user.is_authenticated(), is_authenticated)
-
-    def test_redirect_url(self):
-        """ Verify the view redirects to the correct URL. """
-        response = self.client.get(reverse('logout'))
-        self.assertRedirects(response, LOGOUT_REDIRECT_URL, fetch_redirect_response=False)
-
-    def test_x_frame_options_header(self):
-        """ Verify no X-Frame-Options header is set in the resposne. """
-        response = self.client.get(reverse('logout'))
-        self.assertNotIn('X-Frame-Options', response)
-
-    def test_logout(self):
-        """ Verify the user is logged out of the current session. """
-        self.client.logout()
-        self.assert_authentication_status(False)
-
-        password = 'test'
-        user = User.objects.create_user('test', password=password)
-        self.client.login(username=user.username, password=password)
-        self.assert_authentication_status(True)
-
-        self.client.get(reverse('logout'))
-        self.assert_authentication_status(False)
-
-    def test_no_redirect(self):
-        """ Verify the view does not redirect if the no_redirect querystring parameter is set. """
-        response = self.client.get(reverse('logout') + '?no_redirect=1')
-        self.assertEqual(response.status_code, 200)
+    def get_redirect_url(self):
+        return LOGOUT_REDIRECT_URL

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author='edX',
     author_email='oscm@edx.org',
     license='AGPL',
-    packages=find_packages(exclude=['tests', '*.tests']),
+    packages=find_packages(),
     install_requires=[
         'Django>=1.8,<1.10',
         'python-social-auth>=0.2.19,<1.0.0',


### PR DESCRIPTION
This mixin can be used by the IDAs to test their implementations of the logout view.

ECOM-4607