### PR TITLE
Limit PSA to <0.3.0

### DIFF
--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '0.5.2'  # pragma: no cover
+__version__ = '0.5.3'  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,10 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Django>=1.8,<1.10',
-        'python-social-auth>=0.2.21,<1.0.0',
+        # 0.3.0 introduced a major breaking change, effectively gutting PSA and
+        # moving its Django components to a new social-auth-app-django package.
+        # We may require the new package at some point in the future, once it's stable.
+        'python-social-auth>=0.2.21,<0.3.0',
         'six>=1.10.0,<2.0.0'
     ],
 )


### PR DESCRIPTION
0.3.0 introduced a major breaking change, effectively [gutting PSA and moving its Django components to a new social-auth-app-django package](https://github.com/omab/python-social-auth/blob/master/MIGRATING_TO_SOCIAL.md#migrating-from-python-social-auth-to-split-social). We may require the new package at some point in the future, once it's stable.

@vkaracic @clintonb this will keep things building from scratch until we make the switch to the new, split-up PSA.