### PR TITLE
Support PSA 0.3.0

### DIFF
--- a/auth_backends/strategies.py
+++ b/auth_backends/strategies.py
@@ -4,7 +4,7 @@ Python Social Auth strategies.
 See http://python-social-auth.readthedocs.io/en/latest/strategies.html for more information.
 """
 
-from social.strategies.django_strategy import DjangoStrategy
+from social_django.strategy import DjangoStrategy
 
 
 class EdxDjangoStrategy(DjangoStrategy):

--- a/auth_backends/tests/mixins.py
+++ b/auth_backends/tests/mixins.py
@@ -2,7 +2,7 @@
 
 from django.contrib.auth import get_user, get_user_model
 from django.core.urlresolvers import reverse
-from social.apps.django_app.default.models import UserSocialAuth
+from social_django.models import UserSocialAuth
 
 PASSWORD = 'test'
 User = get_user_model()

--- a/auth_backends/tests/test_strategies.py
+++ b/auth_backends/tests/test_strategies.py
@@ -2,7 +2,7 @@
 from django.conf import settings
 from django.test import TestCase
 from django.test import override_settings
-from social.apps.django_app.utils import load_strategy
+from social_django.utils import load_strategy
 
 from auth_backends.strategies import EdxDjangoStrategy
 

--- a/auth_backends/urls.py
+++ b/auth_backends/urls.py
@@ -9,5 +9,5 @@ from auth_backends.views import EdxOpenIdConnectLoginView, EdxOpenIdConnectLogou
 auth_urlpatterns = [  # pylint: disable=invalid-name
     url(r'^login/$', EdxOpenIdConnectLoginView.as_view(), name='login'),
     url(r'^logout/$', EdxOpenIdConnectLogoutView.as_view(), name='logout'),
-    url('', include('social.apps.django_app.urls', namespace='social')),
+    url('', include('social_django.urls', namespace='social')),
 ]

--- a/auth_backends/views.py
+++ b/auth_backends/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import RedirectView
-from social.apps.django_app.utils import load_strategy, load_backend
+from social_django.utils import load_strategy, load_backend
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup, find_packages
 
 from auth_backends import __version__
 
-
 with open('README.rst') as a, open('HISTORY.rst') as b, open('AUTHORS') as c:
     long_description = '{}\n\n{}\n\n{}'.format(a.read(), b.read(), c.read())
 
@@ -35,10 +34,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Django>=1.8,<1.10',
-        # 0.3.0 introduced a major breaking change, effectively gutting PSA and
-        # moving its Django components to a new social-auth-app-django package.
-        # We may require the new package at some point in the future, once it's stable.
-        'python-social-auth>=0.2.21,<0.3.0',
-        'six>=1.10.0,<2.0.0'
+        'six',
+        'social-auth-core[openidconnect]>1.0.0,<2.0.0',
+        'social-auth-app-django>1.0.0,<2.0.0',
     ],
 )

--- a/test_settings.py
+++ b/test_settings.py
@@ -11,7 +11,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'social.apps.django_app.default',
+    'social_django',
     'auth_backends',
 )
 
@@ -38,12 +38,6 @@ MIDDLEWARE_CLASSES = [
 ]
 
 SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
-
-SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://example.com'
-SOCIAL_AUTH_EDX_OIDC_KEY = 'dummy-key'
-SOCIAL_AUTH_EDX_OIDC_SECRET = 'dummy-secret'
-SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = 'dummy-secret'
-SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL = 'http://example.com/logout/'
 
 EXTRA_SCOPE = []
 COURSE_PERMISSIONS_CLAIMS = []


### PR DESCRIPTION
Installation of auth-backends now requires installation of a new PSA-affiliated package, social-auth-app-django.

@clintonb @vkaracic this is an alternative to https://github.com/edx/auth-backends/pull/27.