### PR TITLE
Added support for a public URL root

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ auth-backends  |Travis|_ |Codecov|_
 .. _Codecov: http://codecov.io/github/edx/auth-backends?branch=master
 
 This repo houses a custom authentication backend, views, and pipeline steps used by edX services for single sign-on.
-This functionality is built atop the `OpenID Connect protocol <http://openid.net/connect/>`_.
+This functionality is built atop the `OpenID Connect (OIDC) protocol <http://openid.net/connect/>`_.
 
 This package is compatible with Python 2.7 and 3.5, and Django 1.8 and 1.9.
 
@@ -46,7 +46,6 @@ The following settings MUST be set:
 +----------------------------------------------+---------------------------------------------------------------------------------------------+
 | SOCIAL_AUTH_STRATEGY                         | Python Social Auth strategy. Set this to `'auth_backends.strategies.EdxDjangoStrategy'`     |
 +----------------------------------------------+---------------------------------------------------------------------------------------------+
-
 
 If your application requires additional user data in the identity token, you can specify additional claims by defining
 the ``EXTRA_SCOPE`` setting. For example, if you wish to have a claim named `preferred_language`, you would include
@@ -110,6 +109,23 @@ This package includes views and urlpatterns configured for edX OpenID Connect. T
 It is recommended that you not modify the login view. If, however, you need to modify the logout view (to redirect to
 a different URL, for example), you can subclass ``EdxOpenIdConnectLogoutView`` for the view and ``LogoutViewTestMixin``
 for your tests.
+
+Devstack
+--------
+When using the Docker-based devstack, it is necessary to have both internal and public URLs for the OAuth/OIDC
+provider. To accommodate this need, set the ``SOCIAL_AUTH_EDX_OIDC_PUBLIC_URL_ROOT`` setting to the value of the
+provider's browser-accessible URL.
+
+.. code-block:: python
+
+    SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://edx.devstack.edxapp:18000/oauth2'
+    SOCIAL_AUTH_EDX_OIDC_PUBLIC_URL_ROOT = 'http://localhost:18000/oauth2'
+
+Additionally, the logout URL should also be browser-accessible:
+
+.. code-block:: python
+
+    SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL = 'http://localhost:18000/logout'
 
 Testing
 -------

--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '0.5.3'  # pragma: no cover
+__version__ = '0.6.0'  # pragma: no cover

--- a/auth_backends/backends.py
+++ b/auth_backends/backends.py
@@ -25,12 +25,12 @@ class EdXOpenIdConnect(OpenIdConnectAuth):
     DEFAULT_SCOPE = ['openid', 'profile', 'email'] + getattr(settings, 'EXTRA_SCOPE', [])
 
     PROFILE_TO_DETAILS_KEY_MAP = {
-        'preferred_username': u'username',
-        'email': u'email',
-        'name': u'full_name',
-        'given_name': u'first_name',
-        'family_name': u'last_name',
-        'locale': u'language',
+        'preferred_username': 'username',
+        'email': 'email',
+        'name': 'full_name',
+        'given_name': 'first_name',
+        'family_name': 'last_name',
+        'locale': 'language',
     }
 
     auth_complete_signal = django.dispatch.Signal(providing_args=['user', 'id_token'])
@@ -43,17 +43,22 @@ class EdXOpenIdConnect(OpenIdConnectAuth):
     @property
     def AUTHORIZATION_URL(self):  # pylint: disable=invalid-name
         """ URL of the auth provider's authorization endpoint. """
-        return '{0}/authorize/'.format(self.setting('URL_ROOT'))
+        url_root = self.setting('PUBLIC_URL_ROOT')
+
+        if not url_root:
+            url_root = self.setting('URL_ROOT')
+
+        return '{}/authorize/'.format(url_root)
 
     @property
     def ACCESS_TOKEN_URL(self):  # pylint: disable=invalid-name
         """ URL of the auth provider's access token endpoint. """
-        return '{0}/access_token/'.format(self.setting('URL_ROOT'))
+        return '{}/access_token/'.format(self.setting('URL_ROOT'))
 
     @property
     def USER_INFO_URL(self):  # pylint: disable=invalid-name
         """ URL of the auth provider's user info endpoint. """
-        return '{0}/user_info/'.format(self.setting('URL_ROOT'))
+        return '{}/user_info/'.format(self.setting('URL_ROOT'))
 
     @property
     def logout_url(self):
@@ -104,10 +109,10 @@ class EdXOpenIdConnect(OpenIdConnectAuth):
         # Limits the scope of languages we can use
         locale = response.get('locale')
         if locale:
-            details[u'language'] = _to_language(response['locale'])
+            details['language'] = _to_language(response['locale'])
 
         # Set superuser bit if the provider determines the user is an administrator
-        details[u'is_superuser'] = details[u'is_staff'] = response.get('administrator', False)
+        details['is_superuser'] = details['is_staff'] = response.get('administrator', False)
 
         return details
 

--- a/auth_backends/tests/test_backends.py
+++ b/auth_backends/tests/test_backends.py
@@ -68,10 +68,23 @@ class EdXOpenIdConnectTests(OpenIdConnectTestMixin, OAuth2Test):
             self.assertDictEqual(actual, {claim[0]: claim[1]})
 
             # Verify the call to the user info endpoint was made with the correct authorization headers
-            headers = {'Authorization': '{token_type} {token}'.format(token_type=expected_token_type,
-                                                                      token=self.fake_access_token)}
+            headers = {
+                'Authorization': '{token_type} {token}'.format(token_type=expected_token_type,
+                                                               token=self.fake_access_token)
+            }
             mock_get_json.assert_called_once_with(self.backend.USER_INFO_URL, headers=headers)
 
     def test_logout_url(self):
         """ Verify the property returns the configured logout URL. """
         self.assertEqual(self.backend.logout_url, self.logout_url)
+
+    def test_authorization_url(self):
+        """ Verify the method utilizes the public URL, if one is set. """
+        authorize_path = '/authorize/'
+        self.assertEqual(self.backend.AUTHORIZATION_URL, self.url_root + authorize_path)
+
+        expected = 'http://public.example.com'
+        # NOTE (CCB): We use the strategy's method, rather than override_settings, because the TestStrategy
+        # class being used does not rely on Django settings.
+        self.strategy.set_settings({'SOCIAL_AUTH_EDX_OIDC_PUBLIC_URL_ROOT': expected})
+        self.assertEqual(self.backend.AUTHORIZATION_URL, expected + authorize_path)


### PR DESCRIPTION
This will allow us to use two different hosts for Docker-based devstack—one for user-facing authorization pages, another for server-to-server communication.

ECOM-6560