### PR TITLE
Corrected pipeline paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,15 @@ The `auth_backends` package can be installed from PyPI using pip::
 
     $ pip install edx-auth-backends
 
+Update ``INSTALLED_APPS``:
+
+.. code-block:: python
+
+    INSTALLED_APPS = (
+        'social_django',
+    )
+
+
 Configuration
 -------------
 Adding single sign-on/out support to a service requires a few changes:
@@ -41,6 +50,8 @@ The following settings MUST be set:
 | SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY | Identity token decryption key (same value as the client secret for edX OpenID Connect)      |
 +----------------------------------------------+---------------------------------------------------------------------------------------------+
 | SOCIAL_AUTH_EDX_OIDC_URL_ROOT                | OAuth/OpenID Connect provider root (e.g. https://courses.stage.edx.org/oauth2)              |
++----------------------------------------------+---------------------------------------------------------------------------------------------+
+| SOCIAL_AUTH_EDX_OIDC_ISSUER                  | OAuth/OpenID Connect provider ID token issuer (e.g. https://courses.stage.edx.org/oauth2)   |
 +----------------------------------------------+---------------------------------------------------------------------------------------------+
 | SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL              | OAuth/OpenID Connect provider's logout page URL (e.g. https://courses.stage.edx.org/logout) |
 +----------------------------------------------+---------------------------------------------------------------------------------------------+

--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '1.0.2'  # pragma: no cover
+__version__ = '1.0.3'  # pragma: no cover

--- a/auth_backends/backends.py
+++ b/auth_backends/backends.py
@@ -110,8 +110,8 @@ class EdXOpenIdConnect(OpenIdConnectAuth):
         return params
 
     def auth_complete(self, *args, **kwargs):
-        # WARNING: During testing, the user model class is `social.tests.models` and not the one
-        # specified for the application.
+        # WARNING: During testing, the user model class is `social_core.tests.models.User`,
+        # not the model specified for the application.
         user = super(EdXOpenIdConnect, self).auth_complete(*args, **kwargs)
         self.auth_complete_signal.send(sender=self.__class__, user=user, id_token=self.id_token)
         return user

--- a/auth_backends/strategies.py
+++ b/auth_backends/strategies.py
@@ -18,20 +18,20 @@ class EdxDjangoStrategy(DjangoStrategy):
     """
     DEFAULT_SETTINGS = {
         'SOCIAL_AUTH_PIPELINE': (
-            'social.pipeline.social_auth.social_details',
-            'social.pipeline.social_auth.social_uid',
-            'social.pipeline.social_auth.auth_allowed',
-            'social.pipeline.social_auth.social_user',
+            'social_core.pipeline.social_auth.social_details',
+            'social_core.pipeline.social_auth.social_uid',
+            'social_core.pipeline.social_auth.auth_allowed',
+            'social_core.pipeline.social_auth.social_user',
 
             # By default python-social-auth will simply create a new user/username if the username
             # from the provider conflicts with an existing username in this system. This custom pipeline function
             # loads existing users instead of creating new ones.
             'auth_backends.pipeline.get_user_if_exists',
-            'social.pipeline.user.get_username',
-            'social.pipeline.user.create_user',
-            'social.pipeline.social_auth.associate_user',
-            'social.pipeline.social_auth.load_extra_data',
-            'social.pipeline.user.user_details'
+            'social_core.pipeline.user.get_username',
+            'social_core.pipeline.user.create_user',
+            'social_core.pipeline.social_auth.associate_user',
+            'social_core.pipeline.social_auth.load_extra_data',
+            'social_core.pipeline.user.user_details'
         ),
 
         # Always raise auth exceptions so that they are properly logged. Otherwise, the PSA middleware will redirect to

--- a/auth_backends/tests/test_backends.py
+++ b/auth_backends/tests/test_backends.py
@@ -6,7 +6,9 @@ from calendar import timegm
 
 import ddt
 import mock
+import pytest
 import six
+from auth_backends.strategies import EdxDjangoStrategy
 from jwkest.jwk import SYMKey
 from jwkest.jws import JWS
 from jwkest.jwt import b64encode_item
@@ -65,6 +67,10 @@ class EdXOpenIdConnectTests(OpenIdConnectTestMixin, OAuth2Test):
             'SOCIAL_AUTH_{0}_ISSUER'.format(self.name): self.issuer,
             'SOCIAL_AUTH_{0}_LOGOUT_URL'.format(self.name): self.logout_url,
         })
+
+        # Use settings from our default strategy so that we can validate them
+        settings.update(EdxDjangoStrategy.DEFAULT_SETTINGS)
+
         return settings
 
     def get_id_token(self, client_key=None, expiration_datetime=None, issue_datetime=None, nonce=None, issuer=None):
@@ -108,6 +114,7 @@ class EdXOpenIdConnectTests(OpenIdConnectTestMixin, OAuth2Test):
 
         return json.dumps(body)
 
+    @pytest.mark.django_db(transaction=False)
     def test_login(self):
         user = self.do_login()
         self.assertIsNotNone(user)


### PR DESCRIPTION
The upgrade from python-social-auth to social-core resulted in packages being moved. We missed this because we never tested the pipeline paths.

The README has also been updated to better reflect the steps needed to properly install this package.

LEARNER-693