### PR TITLE
Removed social_core.pipeline.user.get_username from EdxDjangoStrategy pipeline

### DIFF
--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '1.0.3'  # pragma: no cover
+__version__ = '1.0.4'  # pragma: no cover

--- a/auth_backends/strategies.py
+++ b/auth_backends/strategies.py
@@ -27,7 +27,11 @@ class EdxDjangoStrategy(DjangoStrategy):
             # from the provider conflicts with an existing username in this system. This custom pipeline function
             # loads existing users instead of creating new ones.
             'auth_backends.pipeline.get_user_if_exists',
-            'social_core.pipeline.user.get_username',
+
+            # social_core.pipeline.user.get_username is NOT used because the username should come from the JWS access
+            # token or ID token. There is no need to create a new username.
+            # 'social_core.pipeline.user.get_username',
+
             'social_core.pipeline.user.create_user',
             'social_core.pipeline.social_auth.associate_user',
             'social_core.pipeline.social_auth.load_extra_data',


### PR DESCRIPTION
The get_username creates a unique username by appending a UUID to the username from the ID token. This is not desirable since we need usernames to always be in sync with the authentication provider.