### PR TITLE
ARCH-603: Retrieve and map user_id scope.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,10 @@ Note that the OAuth 2.0 provider uses ``SOCIAL_AUTH_EDX_OAUTH2_ENDPOINT`` to rea
 data returned from this endpoint provides the URLs necessary for authentication as well as the public keys used to
 verify the signed JWT (JWS) access token.
 
+As of auth-backends 2.0.0, oAuth2 Applications require access to the ``user_id`` scope in order for the ``EdXOAuth2`` backend to work.  The backend will write the ``user_id`` into the social-auth extra_data, and can be accessed within the User model as follows::
+
+    self.social_auth.first().extra_data[u'user_id']  # pylint: disable=no-member
+
 
 OIDC Settings (deprecated)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '1.2.2'  # pragma: no cover
+__version__ = '2.0.0'  # pragma: no cover


### PR DESCRIPTION
This library update will be needed by ecommerce in order to get the lms user_id passed through appropriately.

IMPORTANT: This change requires https://github.com/edx/edx-platform/pull/20057 to land before we upgrade services, otherwise edx-platform will send invalid_scope errors.

Additionally, oauth applications are required to have access to the `user_id` scope in order for this not to break oAuth+SSO flow.  There is some follow-up work to ensure this is done for the apps using this flow (ecommerce, credentials, registrar).

ARCH-603