### PR TITLE
Fix anomaly between staff and superuser

### DIFF
--- a/auth_backends/backends.py
+++ b/auth_backends/backends.py
@@ -55,8 +55,8 @@ class EdXBackendMixin(object):
         if locale:
             details['language'] = _to_language(response['locale'])
 
-        # Set superuser bit if the provider determines the user is an administrator
-        details['is_superuser'] = details['is_staff'] = response.get('administrator', False)
+        details['is_staff'] = response.get('administrator', False)
+        details['is_superuser'] = response.get('superuser', False)
 
         return details
 


### PR DESCRIPTION
## [Elevation in permission over OAuth - PROD-123](https://openedx.atlassian.net/browse/PROD-123)
This PR will fix the anomaly when a staff user is also given superuser privileges. We expect that response data will contains details about `superuser` bit to indicate the superuser access level. If the bit is not provided in response, we assume it to be false. 


FYI -- @fysheets 