### PR TITLE
Store refresh_token in extra_data

### DIFF
--- a/auth_backends/backends.py
+++ b/auth_backends/backends.py
@@ -253,9 +253,14 @@ class EdXOAuth2(EdXBackendMixin, BaseOAuth2):
 
     DEFAULT_SCOPE = ['user_id', 'profile', 'email']
     discard_missing_values = True
-    # EXTRA_DATA is used to store the `user_id` from the details in the UserSocialAuth.extra_data field.
+    # EXTRA_DATA is used to store important data in the UserSocialAuth.extra_data field.
     # See https://python-social-auth.readthedocs.io/en/latest/backends/oauth.html?highlight=extra_data
-    EXTRA_DATA = [('user_id', 'user_id', discard_missing_values)]
+    EXTRA_DATA = [
+        # Update the stored user_id, if it's present in the response
+        ('user_id', 'user_id', discard_missing_values),
+        # Update the stored refresh_token, if it's present in the response
+        ('refresh_token', 'refresh_token', discard_missing_values),
+    ]
 
     # local only (not part of social-auth)
     CLAIMS_TO_DETAILS_KEY_MAP = _merge_two_dicts(PROFILE_CLAIMS_TO_DETAILS_KEY_MAP, {

--- a/auth_backends/tests/test_backends.py
+++ b/auth_backends/tests/test_backends.py
@@ -326,6 +326,13 @@ class EdXOAuth2Tests(BackendTestMixin, OAuth2Test):
 
     def test_extra_data(self):
         """
-        Ensure that `user_id` stays in EXTRA_DATA.
+        Ensure that `user_id` and `refresh_token` stay in EXTRA_DATA.
+        The refresh token is required to refresh the user's access
+        token in cases where the client_credentials grant type is not
+        being used, and the application is running on a completely
+        separate domain name.
         """
-        self.assertEqual(self.backend.EXTRA_DATA, [('user_id', 'user_id', True)])
+        self.assertEqual(self.backend.EXTRA_DATA, [
+            ('user_id', 'user_id', True),
+            ('refresh_token', 'refresh_token', True),
+        ])


### PR DESCRIPTION
I'm converting one of our applications from OIDC to the OAuth2/JWT SSO backend, and encountered a regression.

During the SSO process, a unique `access_token` for each user gets saved in the `user_social_auths` `extra_data` field. However, that access token expires after one hour. With the OIDC provider, if the application wanted to get a new access token for the user in question, it could do so using the `refresh_token`, which was also stored in `extra_data`. (Or another option would be to start the SSO process over again, but that's slow, interrupts the user, and doesn't work in non-interactive contexts like backend celery workers.)

However, the OAuth2/JWT backend was not storing the `refresh_token` in `extra_data`. This PR fixes that, so that the refresh token will be stored.

Now, when using the OAuth2/JWT backend, the `refresh_token` will be saved, and applications can get a new `access_token` for the user after the initial one expires, with e.g.

```python
new_token_data = requests.post(f'{openedx_lms_url}/oauth2/access_token', data={
    'client_id': settings.SOCIAL_AUTH_EDX_OAUTH2_KEY,
    'client_secret': settings.SOCIAL_AUTH_EDX_OAUTH2_SECRET,
    'grant_type': 'refresh_token',
    'refresh_token': user_social_auth.extra_data['refresh_token'],
}).json()
user_access_token = new_token_data['access_token']
```
However, some care must be taken as the new access token obtained that way will be a "regular" OAuth2 access token instead of a JWT.