### PR TITLE
ARCHBOM-1213: add changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+**Description:**
+
+Describe in a couple of sentences what this PR adds
+
+**JIRA:**
+
+[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)
+
+**Additional Details**
+
+* **Dependencies:**: List dependencies on other outstanding PRs, issues, etc.
+* **Merge deadline:** List merge deadline (if any)
+* **Testing instructions:** Provide non-trivial testing instructions
+* **Author concerns:** List any concerns about this PR
+
+**Reviewers:**
+- [ ] @edx/arch-review
+- [ ] tag reviewer
+
+**Merge checklist:**
+- [ ] All reviewers approved
+- [ ] CI build is green
+- [ ] Version bump if needed
+- [ ] Changelog record added
+- [ ] Documentation updated (not only docstrings)
+- [ ] Commits are squashed
+
+**Post merge:**
+- [ ] Create a tag
+- [ ] Check new version is pushed to PyPi after tag-triggered build is 
+      finished.
+- [ ] Delete working branch (if not needed anymore)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,55 @@
+Change Log
+==========
+
+..
+   This file loosely adheres to the structure of https://keepachangelog.com/,
+   but in reStructuredText instead of Markdown.
+
+   This project adheres to Semantic Versioning (https://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.
+
+Unreleased
+----------
+
+*
+
+
+[3.1.0] - 2020-05-08
+--------------------
+
+Added
+~~~~~
+
+* Add python 3.8 support
+
+Removed
+~~~~~~~
+
+* Removed Django <2.2
+
+[3.0.2] - 2020-02-06
+--------------------
+
+No functional changes. Fixed release version.
+
+[3.0.1] - 2020-02-06
+--------------------
+
+No functional changes. 3.0.0 had failed to release.
+
+[3.0.0] - 2020-02-06
+--------------------
+
+Removed
+~~~~~~~
+
+* **BREAKING CHANGE**: Remove (deprecated) OpenID Connect support
+* **BREAKING CHANGE**: Remove Django <1.11 support
+* Remove testing of Python 3.6
+
+Added
+~~~~~
+
+* Add support for Django 2.2
+* Add testing of Python 3.5

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,16 @@ Testing
 
 Call ``make test``.
 
+Publishing a Release
+--------------------
+
+After a PR merges, a new version of the package will automatically be released by Travis when the commit is tagged. Use::
+
+    git tag -a X.Y.Z -m "Releasing version X.Y.Z"
+    git push origin X.Y.Z
+
+Do **not** create a Github Release, or ensure its message points to the CHANGELOG.rst and ADR 0001-use-changelog.rst.
+
 License
 -------
 

--- a/auth_backends/docs/decisions/0001-use-changelog.rst
+++ b/auth_backends/docs/decisions/0001-use-changelog.rst
@@ -1,0 +1,18 @@
+1. Use CHANGELOG.rst
+====================
+
+Status
+------
+
+Accepted
+
+Decision
+--------
+
+* Add a CHANGELOG.rst as the primary source of tracking changes.
+* The changelog will be formatted according to `keepachangelog.com`_.
+* Avoid redundancy in Github Releases.
+
+For more background or details of this decision, see duplicate `0001-use-changelog.rst decision in edx-drf-extensions`_.
+
+.. _0001-use-changelog.rst decision in edx-drf-extensions: https://github.com/edx/edx-drf-extensions/blob/master/docs/decisions/0001-use-changelog.rst


### PR DESCRIPTION
Post Merge:
- [ ] Update 3.x Github Release notes to read like this one: https://github.com/edx/edx-drf-extensions/releases/tag/6.0.0

- add CHANGELOG.rst
- add ADR for switching to CHANGELOG.rst
- add PR template
- add README instructions for releasing

ARCHBOM-1213