### PR TITLE
Downgraded social-auth-core to use 3.2.0

### DIFF
--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '3.1.0'  # pragma: no cover
+__version__ = '3.2.0'  # pragma: no cover

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,21 +5,18 @@
 #    make upgrade
 #
 certifi==2020.4.5.1       # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.9.2       # via social-auth-core
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in
 idna==2.9                 # via requests
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-pycparser==2.20           # via cffi
 pyjwt==1.7.1              # via -r requirements/base.in, social-auth-core
 python3-openid==3.1.0     # via social-auth-core
 pytz==2020.1              # via django
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via requests-oauthlib, social-auth-core
-six==1.14.0               # via -r requirements/base.in, cryptography, social-auth-app-django, social-auth-core
+six==1.14.0               # via -r requirements/base.in, social-auth-app-django, social-auth-core
 social-auth-app-django==3.1.0  # via -r requirements/base.in
-social-auth-core==3.3.3   # via -r requirements/base.in, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.in, social-auth-app-django
 sqlparse==0.3.1           # via django
 urllib3==1.25.9           # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,4 +12,5 @@
 Django<2.3
 
 
-
+# stay on 3.2.0, details here https://openedx.atlassian.net/browse/BOM-1629
+social-auth-core==3.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,18 +4,16 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
+appdirs==1.4.4            # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
 argparse==1.4.0           # via -r requirements/test.txt, unittest2
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 certifi==2020.4.5.1       # via -r requirements/test.txt, -r requirements/travis.txt, requests
-cffi==1.14.0              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
 codecov==2.0.22           # via -r requirements/travis.txt
 coverage==5.1             # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
-cryptography==2.9.2       # via -r requirements/test.txt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 distlib==0.3.0            # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt
@@ -37,8 +35,7 @@ pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pip-tools==5.1.2          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 py==1.8.1                 # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
-pycodestyle==2.5.0        # via -r requirements/test.txt
-pycparser==2.20           # via -r requirements/test.txt, cffi
+pycodestyle==2.6.0        # via -r requirements/test.txt
 pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/test.txt
 pyjwt==1.7.1              # via -r requirements/test.txt, social-auth-core
@@ -49,16 +46,16 @@ pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celer
 pyparsing==2.4.7          # via -r requirements/test.txt, -r requirements/travis.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/test.txt, django
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.23.0          # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pyjwkest, requests-oauthlib, social-auth-core
-six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, cryptography, edx-lint, packaging, pathlib2, pip-tools, pyjwkest, social-auth-app-django, social-auth-core, tox, unittest2, virtualenv
+six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, packaging, pathlib2, pip-tools, pyjwkest, social-auth-app-django, social-auth-core, tox, unittest2, virtualenv
 social-auth-app-django==3.1.0  # via -r requirements/test.txt
-social-auth-core==3.3.3   # via -r requirements/test.txt, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/test.txt, django
-toml==0.10.0              # via -r requirements/test.txt, -r requirements/travis.txt, tox
+toml==0.10.1              # via -r requirements/test.txt, -r requirements/travis.txt, tox
 tox-battery==0.5.2        # via -r requirements/travis.txt
 tox==3.15.0               # via -r requirements/test.txt, -r requirements/travis.txt, tox-battery
 traceback2==1.4.0         # via -r requirements/test.txt, unittest2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,17 +4,15 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via virtualenv
+appdirs==1.4.4            # via virtualenv
 argparse==1.4.0           # via unittest2
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 certifi==2020.4.5.1       # via -r requirements/base.txt, requests
-cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==5.1             # via -r requirements/test.in, pytest-cov
-cryptography==2.9.2       # via -r requirements/base.txt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
 edx-lint==1.4.1           # via -r requirements/test.in
@@ -34,8 +32,7 @@ packaging==20.3           # via pytest, tox
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest, tox
 py==1.8.1                 # via pytest, tox
-pycodestyle==2.5.0        # via -r requirements/test.in
-pycparser==2.20           # via -r requirements/base.txt, cffi
+pycodestyle==2.6.0        # via -r requirements/test.in
 pycryptodomex==3.9.7      # via pyjwkest
 pyjwkest==1.4.2           # via -r requirements/test.in
 pyjwt==1.7.1              # via -r requirements/base.txt, social-auth-core
@@ -46,16 +43,16 @@ pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.1             # via pytest-cov, pytest-django
+pytest==5.4.2             # via pytest-cov, pytest-django
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, django
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, pyjwkest, requests-oauthlib, social-auth-core
-six==1.14.0               # via -r requirements/base.txt, astroid, cryptography, edx-lint, packaging, pathlib2, pyjwkest, social-auth-app-django, social-auth-core, tox, unittest2, virtualenv
+six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, packaging, pathlib2, pyjwkest, social-auth-app-django, social-auth-core, tox, unittest2, virtualenv
 social-auth-app-django==3.1.0  # via -r requirements/base.txt
-social-auth-core==3.3.3   # via -r requirements/base.txt, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-toml==0.10.0              # via tox
+toml==0.10.1              # via tox
 tox==3.15.0               # via -r requirements/test.in
 traceback2==1.4.0         # via unittest2
 typed-ast==1.4.1          # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via virtualenv
+appdirs==1.4.4            # via virtualenv
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.22           # via -r requirements/travis.in
@@ -20,7 +20,7 @@ py==1.8.1                 # via tox
 pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via codecov
 six==1.14.0               # via packaging, tox, virtualenv
-toml==0.10.0              # via tox
+toml==0.10.1              # via tox
 tox-battery==0.5.2        # via -r requirements/travis.in
 tox==3.15.0               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests


### PR DESCRIPTION
**Description:**

downgraded the social-auth-core to stay at 3.2.0, relevant JIRA issue [here](https://openedx.atlassian.net/browse/BOM-1636)