### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 auth-backends  |Travis|_ |Codecov|_
 ===================================
-.. |Travis| image:: https://travis-ci.org/edx/auth-backends.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/auth-backends
+.. |Travis| image:: https://travis-ci.com/edx/auth-backends.svg?branch=master
+.. _Travis: https://travis-ci.com/edx/auth-backends
 
 .. |Codecov| image:: http://codecov.io/github/edx/auth-backends/coverage.svg?branch=master
 .. _Codecov: http://codecov.io/github/edx/auth-backends?branch=master


### PR DESCRIPTION
Updated the README file.
Travis badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089