### PR TITLE
BOM-2187 : Unpin social-auth-core

### DIFF
--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '3.2.0'  # pragma: no cover
+__version__ = '3.3.0'  # pragma: no cover

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,18 +5,21 @@
 #    make upgrade
 #
 certifi==2020.12.5        # via requests
+cffi==1.14.4              # via cryptography
 chardet==4.0.0            # via requests
+cryptography==3.3.1       # via social-auth-core
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in
 idna==2.10                # via requests
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-pyjwt==1.7.1              # via -r requirements/base.in, social-auth-core
+pycparser==2.20           # via cffi
+pyjwt==2.0.0              # via -r requirements/base.in, social-auth-core
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.5              # via django
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.25.1          # via requests-oauthlib, social-auth-core
-six==1.15.0               # via -r requirements/base.in, social-auth-app-django, social-auth-core
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.in
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.in, social-auth-app-django
+six==1.15.0               # via -r requirements/base.in, cryptography, social-auth-app-django, social-auth-core
+social-auth-app-django==4.0.0  # via -r requirements/base.in
+social-auth-core==3.3.3   # via -r requirements/base.in, social-auth-app-django
 sqlparse==0.4.1           # via django
 urllib3==1.26.2           # via requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ django==2.2.17            # via -c requirements/constraints.txt, -r requirements
 idna==2.10                # via requests
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 pycparser==2.20           # via cffi
-pyjwt==2.0.0              # via -r requirements/base.in, social-auth-core
+pyjwt==1.7.1              # via -c requirements/constraints.txt, -r requirements/base.in, social-auth-core
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.5              # via django
 requests-oauthlib==1.3.0  # via social-auth-core

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,8 +12,6 @@ coverage==5.3.1           # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
 packaging==20.8           # via tox
 pluggy==0.13.1            # via tox
 py==1.10.0                # via tox
@@ -25,4 +23,3 @@ tox-battery==0.6.1        # via -r requirements/ci.in
 tox==3.20.1               # via -r requirements/ci.in, tox-battery
 urllib3==1.26.2           # via requests
 virtualenv==20.2.2        # via tox
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,6 @@
 
 # stay on LTS
 Django<2.3
+
+# Test fails on newer versions with `It is required that you pass in a value for the "algorithms" argument when calling decode()`
+pyjwt<2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,12 +10,3 @@
 
 # stay on LTS
 Django<2.3
-
-# stay on social-auth-app-django 3.1.0 because newer versions require versions of social-auth-core > 3.4.0
-social-auth-app-django==3.1.0
-
-# stay on 3.2.0, details here https://openedx.atlassian.net/browse/BOM-1629
-social-auth-core==3.2.0
-
-# zipp > 1.2.0 does not support Python 3.5
-zipp==1.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,7 +39,7 @@ pycodestyle==2.6.0        # via -r requirements/test.txt
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/test.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/test.txt
-pyjwt==2.0.0              # via -r requirements/test.txt, social-auth-core
+pyjwt==1.7.1              # via -c requirements/constraints.txt, -r requirements/test.txt, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.3.0      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,11 +9,13 @@ argparse==1.4.0           # via -r requirements/test.txt, unittest2
 astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
 certifi==2020.12.5        # via -r requirements/ci.txt, -r requirements/test.txt, requests
+cffi==1.14.4              # via -r requirements/test.txt, cryptography
 chardet==4.0.0            # via -r requirements/ci.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
 codecov==2.1.11           # via -r requirements/ci.txt
 coverage==5.3.1           # via -r requirements/ci.txt, -r requirements/test.txt, codecov, pytest-cov
+cryptography==3.3.1       # via -r requirements/test.txt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 distlib==0.3.1            # via -r requirements/ci.txt, -r requirements/test.txt, virtualenv
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt
@@ -22,10 +24,8 @@ filelock==3.0.12          # via -r requirements/ci.txt, -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 httpretty==1.0.5          # via -r requirements/test.txt
 idna==2.10                # via -r requirements/ci.txt, -r requirements/test.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/ci.txt, -r requirements/test.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.2.1  # via -r requirements/ci.txt, -r requirements/test.txt, virtualenv
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/test.txt, pylint
+isort==5.7.0              # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 linecache2==1.0.0         # via -r requirements/test.txt, traceback2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
@@ -36,9 +36,10 @@ pip-tools==5.5.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/ci.txt, -r requirements/test.txt, pytest, tox
 py==1.10.0                # via -r requirements/ci.txt, -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.txt
+pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/test.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/test.txt
-pyjwt==1.7.1              # via -r requirements/test.txt, social-auth-core
+pyjwt==2.0.0              # via -r requirements/test.txt, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.3.0      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
@@ -46,14 +47,14 @@ pylint==2.6.0             # via -r requirements/test.txt, edx-lint, pylint-celer
 pyparsing==2.4.7          # via -r requirements/ci.txt, -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.5              # via -r requirements/test.txt, django
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.25.1          # via -r requirements/ci.txt, -r requirements/test.txt, codecov, pyjwkest, requests-oauthlib, social-auth-core
-six==1.15.0               # via -r requirements/ci.txt, -r requirements/test.txt, astroid, edx-lint, pathlib2, pyjwkest, social-auth-app-django, social-auth-core, tox, unittest2, virtualenv
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, social-auth-app-django
+six==1.15.0               # via -r requirements/ci.txt, -r requirements/test.txt, astroid, cryptography, edx-lint, pyjwkest, social-auth-app-django, social-auth-core, tox, unittest2, virtualenv
+social-auth-app-django==4.0.0  # via -r requirements/test.txt
+social-auth-core==3.3.3   # via -r requirements/test.txt, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 toml==0.10.2              # via -r requirements/ci.txt, -r requirements/test.txt, pylint, pytest, tox
 tox-battery==0.6.1        # via -r requirements/ci.txt
@@ -64,7 +65,6 @@ unittest2==1.1.0          # via -r requirements/test.txt
 urllib3==1.26.2           # via -r requirements/ci.txt, -r requirements/test.txt, requests
 virtualenv==20.2.2        # via -r requirements/ci.txt, -r requirements/test.txt, tox
 wrapt==1.12.1             # via -r requirements/test.txt, astroid
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/ci.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,10 +9,12 @@ argparse==1.4.0           # via unittest2
 astroid==2.4.2            # via pylint, pylint-celery
 attrs==20.3.0             # via pytest
 certifi==2020.12.5        # via -r requirements/base.txt, requests
+cffi==1.14.4              # via -r requirements/base.txt, cryptography
 chardet==4.0.0            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==5.3.1           # via -r requirements/test.in, pytest-cov
+cryptography==3.3.1       # via -r requirements/base.txt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 distlib==0.3.1            # via virtualenv
 edx-lint==1.6             # via -r requirements/test.in
@@ -20,22 +22,20 @@ filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via pyjwkest
 httpretty==1.0.5          # via -r requirements/test.in
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==2.1.1  # via pluggy, pytest, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
 iniconfig==1.1.1          # via pytest
-isort==4.3.21             # via pylint
+isort==5.7.0              # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 linecache2==1.0.0         # via traceback2
 mccabe==0.6.1             # via pylint
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 packaging==20.8           # via pytest, tox
-pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest, tox
 py==1.10.0                # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.in
+pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.9      # via pyjwkest
 pyjwkest==1.4.2           # via -r requirements/test.in
-pyjwt==1.7.1              # via -r requirements/base.txt, social-auth-core
+pyjwt==2.0.0              # via -r requirements/base.txt, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
@@ -43,14 +43,14 @@ pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==4.1.0      # via -r requirements/test.in
-pytest==6.1.2             # via pytest-cov, pytest-django
+pytest==6.2.1             # via pytest-cov, pytest-django
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.5              # via -r requirements/base.txt, django
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.25.1          # via -r requirements/base.txt, pyjwkest, requests-oauthlib, social-auth-core
-six==1.15.0               # via -r requirements/base.txt, astroid, edx-lint, pathlib2, pyjwkest, social-auth-app-django, social-auth-core, tox, unittest2, virtualenv
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-app-django
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, edx-lint, pyjwkest, social-auth-app-django, social-auth-core, tox, unittest2, virtualenv
+social-auth-app-django==4.0.0  # via -r requirements/base.txt
+social-auth-core==3.3.3   # via -r requirements/base.txt, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 toml==0.10.2              # via pylint, pytest, tox
 tox==3.20.1               # via -r requirements/test.in
@@ -60,4 +60,3 @@ unittest2==1.1.0          # via -r requirements/test.in
 urllib3==1.26.2           # via -r requirements/base.txt, requests
 virtualenv==20.2.2        # via tox
 wrapt==1.12.1             # via astroid
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -35,7 +35,7 @@ pycodestyle==2.6.0        # via -r requirements/test.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.9      # via pyjwkest
 pyjwkest==1.4.2           # via -r requirements/test.in
-pyjwt==2.0.0              # via -r requirements/base.txt, social-auth-core
+pyjwt==1.7.1              # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
         'Framework :: Django :: 2.2',


### PR DESCRIPTION
The bug mentioned on [ARCHBOM-1078](https://openedx.atlassian.net/browse/ARCHBOM-1078) is fixed in `social-auth-core==3.3.3`, See [this comment](https://openedx.atlassian.net/browse/BOM-2094?focusedCommentId=514498) for details, now we are unpinning it wherever it was previously pinned due to that bug.
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2187