### PR TITLE
BOM-2550: Pin social-auth-core<=4.0.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,12 +11,14 @@ cffi==1.14.5
 chardet==4.0.0
     # via requests
 cryptography==3.4.7
-    # via social-auth-core
+    # via
+    #   pyjwt
+    #   social-auth-core
 defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==2.2.20
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -28,8 +30,9 @@ oauthlib==3.1.0
     #   social-auth-core
 pycparser==2.20
     # via cffi
-pyjwt==1.7.1
+pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   social-auth-core
@@ -43,7 +46,7 @@ requests==2.25.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/base.in
     #   social-auth-app-django
@@ -52,7 +55,7 @@ social-auth-app-django==4.0.0
     # via -r requirements/base.in
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   social-auth-app-django
 sqlparse==0.4.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -32,7 +32,7 @@ pyparsing==2.4.7
     # via packaging
 requests==2.25.1
     # via codecov
-six==1.15.0
+six==1.16.0
     # via
     #   tox
     #   virtualenv
@@ -40,11 +40,11 @@ toml==0.10.2
     # via tox
 tox-battery==0.6.1
     # via -r requirements/ci.in
-tox==3.23.0
+tox==3.23.1
     # via
     #   -r requirements/ci.in
     #   tox-battery
 urllib3==1.26.4
     # via requests
-virtualenv==20.4.3
+virtualenv==20.4.6
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,7 +12,7 @@
 # This file contains all common constraints for edx-repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-
-
 # greater versions causing failures in IDAs.
 pyjwt==1.7.1
+# social-auth-core>=4.0.3 requires PyJWT>=2.0.0
+social-auth-core<4.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,12 +13,12 @@ argparse==1.4.0
     # via
     #   -r requirements/test.txt
     #   unittest2
-astroid==2.5.3
+astroid==2.5.6
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -42,6 +42,7 @@ click-log==0.3.2
     #   edx-lint
 click==7.1.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
     #   click-log
@@ -54,7 +55,7 @@ code-annotations==1.1.1
     #   edx-lint
 codecov==2.1.11
     # via -r requirements/ci.txt
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -63,6 +64,7 @@ coverage==5.5
 cryptography==3.4.7
     # via
     #   -r requirements/test.txt
+    #   pyjwt
     #   social-auth-core
 defusedxml==0.7.1
     # via
@@ -74,7 +76,7 @@ distlib==0.3.1
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   virtualenv
-django==2.2.20
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -92,7 +94,7 @@ future==0.18.2
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-httpretty==1.0.5
+httpretty==1.1.1
     # via -r requirements/test.txt
 idna==2.10
     # via
@@ -109,6 +111,7 @@ isort==5.8.0
     #   pylint
 jinja2==2.11.3
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
 lazy-object-proxy==1.6.0
@@ -121,6 +124,7 @@ linecache2==1.0.0
     #   traceback2
 markupsafe==1.1.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   jinja2
 mccabe==0.6.1
@@ -138,7 +142,7 @@ packaging==20.9
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -172,8 +176,9 @@ pycryptodomex==3.10.1
     #   pyjwkest
 pyjwkest==1.4.2
     # via -r requirements/test.txt
-pyjwt==1.7.1
+pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   social-auth-core
@@ -181,7 +186,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.4.3
+pylint-django==2.4.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -190,7 +195,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.4
+pylint==2.8.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -202,16 +207,16 @@ pyparsing==2.4.7
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   packaging
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/test.txt
-pytest-django==4.2.0
+pytest-django==4.3.0
     # via -r requirements/test.txt
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -239,7 +244,7 @@ requests==2.25.1
     #   pyjwkest
     #   requests-oauthlib
     #   social-auth-core
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -254,7 +259,7 @@ social-auth-app-django==4.0.0
     # via -r requirements/test.txt
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   social-auth-app-django
 sqlparse==0.4.1
@@ -274,13 +279,14 @@ toml==0.10.2
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
+    #   coverage
     #   pep517
     #   pylint
     #   pytest
     #   tox
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-tox==3.23.0
+tox==3.23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -296,7 +302,7 @@ urllib3==1.26.4
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
-virtualenv==20.4.3
+virtualenv==20.4.6
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,9 @@
 #    make upgrade
 #
 click==7.1.2
-    # via pip-tools
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   pip-tools
 pep517==0.10.0
     # via pip-tools
 pip-tools==6.1.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.36.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.0.1
+pip==21.1.1
     # via -r requirements/pip.in
-setuptools==56.0.0
+setuptools==56.2.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,11 +8,11 @@ appdirs==1.4.4
     # via virtualenv
 argparse==1.4.0
     # via unittest2
-astroid==2.5.3
+astroid==2.5.6
     # via
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via pytest
 certifi==2020.12.5
     # via
@@ -30,18 +30,20 @@ click-log==0.3.2
     # via edx-lint
 click==7.1.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
 code-annotations==1.1.1
     # via edx-lint
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
 cryptography==3.4.7
     # via
     #   -r requirements/base.txt
+    #   pyjwt
     #   social-auth-core
 defusedxml==0.7.1
     # via
@@ -63,7 +65,7 @@ filelock==3.0.12
     #   virtualenv
 future==0.18.2
     # via pyjwkest
-httpretty==1.0.5
+httpretty==1.1.1
     # via -r requirements/test.in
 idna==2.10
     # via
@@ -74,13 +76,17 @@ iniconfig==1.1.1
 isort==5.8.0
     # via pylint
 jinja2==2.11.3
-    # via code-annotations
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   code-annotations
 lazy-object-proxy==1.6.0
     # via astroid
 linecache2==1.0.0
     # via traceback2
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   jinja2
 mccabe==0.6.1
     # via pylint
 oauthlib==3.1.0
@@ -92,7 +98,7 @@ packaging==20.9
     # via
     #   pytest
     #   tox
-pbr==5.5.1
+pbr==5.6.0
     # via stevedore
 pluggy==0.13.1
     # via
@@ -112,20 +118,21 @@ pycryptodomex==3.10.1
     # via pyjwkest
 pyjwkest==1.4.2
     # via -r requirements/test.in
-pyjwt==1.7.1
+pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   social-auth-core
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.4.3
+pylint-django==2.4.4
     # via edx-lint
 pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.7.4
+pylint==2.8.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -133,15 +140,15 @@ pylint==2.7.4
     #   pylint-plugin-utils
 pyparsing==2.4.7
     # via packaging
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/test.in
-pytest-django==4.2.0
+pytest-django==4.3.0
     # via -r requirements/test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   pytest-cov
     #   pytest-django
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via code-annotations
 python3-openid==3.2.0
     # via
@@ -163,7 +170,7 @@ requests==2.25.1
     #   pyjwkest
     #   requests-oauthlib
     #   social-auth-core
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/base.txt
     #   edx-lint
@@ -177,7 +184,7 @@ social-auth-app-django==4.0.0
     # via -r requirements/base.txt
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   social-auth-app-django
 sqlparse==0.4.1
@@ -190,10 +197,11 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via
+    #   coverage
     #   pylint
     #   pytest
     #   tox
-tox==3.23.0
+tox==3.23.1
     # via -r requirements/test.in
 traceback2==1.4.0
     # via unittest2
@@ -203,7 +211,7 @@ urllib3==1.26.4
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.4.3
+virtualenv==20.4.6
     # via tox
 wrapt==1.12.1
     # via astroid


### PR DESCRIPTION
**Issue:** [BOM-2550](https://openedx.atlassian.net/browse/BOM-2550)

### Description
- `social-auth-core>=4.0.3` requires `PyJWT>=2.0.0` which conflicts with the current `PyJWT==1.7.1` constraint.