### PR TITLE
Latest version of pyjwt needs some critical changes.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,16 @@ Unreleased
 
 *
 
+[4.0.0] - 2021-08-05
+--------------------
+
+Changed
+~~~~~~~
+
+* **BREAKING CHANGE:** ``jwt.decode``: Inside ``EdXOAuth2::user_data`` Require explicit algorithms by default.
+* **BREAKING CHANGE:** Upgraded dependency ``pyjwt[crypto]`` to 2.1.0, which introduces its own breaking changes that may affect consumers of this library. Pay careful attention to the 2.0.0 breaking changes documented in https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0.
+
+
 [3.4.0] - 2021-07-07
 --------------------
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ $(COMMON_CONSTRAINTS_TXT):
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+	sed 's/pyjwt\[crypto\]==1.7.1//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/social-auth-core<4.0.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	pip install -qr requirements/pip-tools.txt
 	# Make sure to compile files after any other files they include!
 	$(PIP_COMPILE) --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in

--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '3.4.0'  # pragma: no cover
+__version__ = '4.0.0'  # pragma: no cover

--- a/auth_backends/backends.py
+++ b/auth_backends/backends.py
@@ -100,8 +100,9 @@ class EdXOAuth2(BaseOAuth2):
         return user
 
     def user_data(self, access_token, *args, **kwargs):
-        decoded_access_token = jwt.decode(access_token, verify=False)
-
+        # The algorithm is required but unused because signature verification is skipped.
+        # Note: signature verification happens earlier during the authentication process.
+        decoded_access_token = jwt.decode(access_token, algorithms=["HS256"], options={"verify_signature": False})
         keys = list(self.CLAIMS_TO_DETAILS_KEY_MAP.keys()) + ['administrator', 'superuser']
         user_data = {key: decoded_access_token[key] for key in keys if key in decoded_access_token}
         return user_data

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 Django
-PyJWT
+pyjwt[crypto]>=2.1.0       # depends on newer jwt.decode and jwt.encode functionality
 six
 social-auth-app-django
 social-auth-core           # Common auth interfaces

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,10 +30,8 @@ oauthlib==3.1.1
     #   social-auth-core
 pycparser==2.20
     # via cffi
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   social-auth-core
 python3-openid==3.2.0
@@ -50,15 +48,12 @@ six==1.16.0
     # via
     #   -r requirements/base.in
     #   social-auth-app-django
-    #   social-auth-core
 social-auth-app-django==4.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-social-auth-core==4.0.2
+social-auth-core==4.1.0
     # via
-    #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   social-auth-app-django
 sqlparse==0.4.1

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -19,10 +19,10 @@ Django<2.3
 drf-jwt<1.19.1
 
 # Newer versions causing tests failures in multiple repos.
-pyjwt[crypto]==1.7.1
+
 
 # latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2
-social-auth-core<4.0.3
+
 
 # 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
 social-auth-app-django<5.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,8 +9,3 @@
 # linking to it here is good.
 
 -c common_constraints.txt
-
-# greater versions causing failures in IDAs.
-pyjwt==1.7.1
-# social-auth-core>=4.0.3 requires PyJWT>=2.0.0
-social-auth-core<4.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -177,10 +177,8 @@ pycryptodomex==3.10.1
     #   pyjwkest
 pyjwkest==1.4.2
     # via -r requirements/test.txt
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   social-auth-core
 pylint==2.9.6
@@ -252,7 +250,6 @@ six==1.16.0
     #   edx-lint
     #   pyjwkest
     #   social-auth-app-django
-    #   social-auth-core
     #   tox
     #   unittest2
     #   virtualenv
@@ -260,10 +257,8 @@ social-auth-app-django==4.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
-social-auth-core==4.0.2
+social-auth-core==4.1.0
     # via
-    #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   social-auth-app-django
 sqlparse==0.4.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -114,10 +114,8 @@ pycryptodomex==3.10.1
     # via pyjwkest
 pyjwkest==1.4.2
     # via -r requirements/test.in
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   social-auth-core
 pylint==2.9.6
@@ -172,7 +170,6 @@ six==1.16.0
     #   edx-lint
     #   pyjwkest
     #   social-auth-app-django
-    #   social-auth-core
     #   tox
     #   unittest2
     #   virtualenv
@@ -180,10 +177,8 @@ social-auth-app-django==4.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
-social-auth-core==4.0.2
+social-auth-core==4.1.0
     # via
-    #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   social-auth-app-django
 sqlparse==0.4.1


### PR DESCRIPTION
In blockstore with latest version of pyjwt=2.1.0 this error appears.
`It is required that you pass in a value for the "algorithms" argument when calling decode().`

Its due to this change.
https://pyjwt.readthedocs.io/en/stable/changelog.html#dropped-deprecated-verify-expiration-param-in-jwt-decode

This PR constains major changes.
---------------------------
* **BREAKING CHANGE:** ``jwt.decode``: Inside ``EdXOAuth2::user_data`` Require explicit algorithms by default.
* **BREAKING CHANGE:** Upgraded dependency ``pyjwt[crypto]`` to 2.1.0, which introduces its own breaking changes that may affect consumers of this library. Pay careful attention to the 2.0.0 breaking changes documented in https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0.