### PR TITLE
Sync common constraint locally to fix override version issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,14 @@ test:
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
 PIP_COMPILE = pip-compile --upgrade $(PIP_COMPILE_OPTS)
 
+
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -qr requirements/pip-tools.txt
 	# Make sure to compile files after any other files they include!
 	$(PIP_COMPILE) --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ defusedxml==0.7.1
     #   social-auth-core
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
 idna==3.2
     # via requests
@@ -32,7 +32,7 @@ pycparser==2.20
     # via cffi
 pyjwt[crypto]==1.7.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   social-auth-core
@@ -52,10 +52,12 @@ six==1.16.0
     #   social-auth-app-django
     #   social-auth-core
 social-auth-app-django==4.0.0
-    # via -r requirements/base.in
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/base.in
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   social-auth-app-django

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,28 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<2.3
+
+# latest version is causing e2e failures in edx-platform.
+drf-jwt<1.19.1
+
+# Newer versions causing tests failures in multiple repos.
+pyjwt[crypto]==1.7.1
+
+# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2
+social-auth-core<4.0.3
+
+# 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
+social-auth-app-django<5.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,9 +8,7 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-
-# This file contains all common constraints for edx-repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+-c common_constraints.txt
 
 # greater versions causing failures in IDAs.
 pyjwt==1.7.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -77,7 +77,7 @@ distlib==0.3.2
     #   virtualenv
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
     #   edx-lint
 edx-lint==5.0.0
@@ -179,7 +179,7 @@ pyjwkest==1.4.2
     # via -r requirements/test.txt
 pyjwt[crypto]==1.7.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   social-auth-core
@@ -257,10 +257,12 @@ six==1.16.0
     #   unittest2
     #   virtualenv
 social-auth-app-django==4.0.0
-    # via -r requirements/test.txt
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test.txt
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   social-auth-app-django
@@ -284,7 +286,7 @@ toml==0.10.2
     #   pytest
     #   pytest-cov
     #   tox
-tomli==1.2.0
+tomli==1.2.1
     # via
     #   -r requirements/pip-tools.txt
     #   pep517

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip-tools.in
-tomli==1.2.0
+tomli==1.2.1
     # via pep517
 wheel==0.36.2
     # via pip-tools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.36.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.2
+pip==21.2.3
     # via -r requirements/pip.in
 setuptools==57.4.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -52,7 +52,7 @@ defusedxml==0.7.1
 distlib==0.3.2
     # via virtualenv
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-lint
 edx-lint==5.0.0
@@ -116,7 +116,7 @@ pyjwkest==1.4.2
     # via -r requirements/test.in
 pyjwt[crypto]==1.7.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   social-auth-core
@@ -177,10 +177,12 @@ six==1.16.0
     #   unittest2
     #   virtualenv
 social-auth-app-django==4.0.0
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/base.txt
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   social-auth-app-django


### PR DESCRIPTION
Implemented common-constraint local sync. It gives us more control in case of different version implementation.

pip-tools gives error if two different versions of same package appears in make upgrade job. To fix this problem, added common constraint locally. It will always sync with web-url. With this approach this issue can be resolve.
