### PR TITLE
BOM-2774: Fix the PyJwt common constraint handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ $(COMMON_CONSTRAINTS_TXT):
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
-	sed 's/pyjwt\[crypto\]==1.7.1//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	sed 's/pyjwt\[crypto\]<2.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	sed 's/social-auth-core<4.0.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ cffi==1.14.6
     # via cryptography
 charset-normalizer==2.0.4
     # via requests
-cryptography==3.4.7
+cryptography==3.4.8
     # via
     #   pyjwt
     #   social-auth-core

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -24,10 +24,12 @@ idna==3.2
     # via requests
 packaging==21.0
     # via tox
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via virtualenv
 pluggy==0.13.1
-    # via tox
+    # via
+    #   -c requirements/common_constraints.txt
+    #   tox
 py==1.10.0
     # via tox
 pyparsing==2.4.7
@@ -40,7 +42,7 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.1
+tox==3.24.3
     # via
     #   -r requirements/ci.in
     #   tox-battery
@@ -48,5 +50,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 urllib3==1.26.6
     # via requests
-virtualenv==20.7.0
+virtualenv==20.7.2
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -16,13 +16,22 @@
 Django<2.3
 
 # latest version is causing e2e failures in edx-platform.
+# See  comment.
 drf-jwt<1.19.1
 
-# Newer versions causing tests failures in multiple repos.
+# 4.0.0 requires pyjwt[crypto] 2.1.0. See  comment.
+edx-auth-backends<4.0.0
 
-
-# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2
-
+# 7.0.0 requires pyjwt[crypto] 2.1.0. See  comment.
+edx-drf-extensions<7.0.0
 
 # 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
 social-auth-app-django<5.0.0
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+# pluggy released 1.0.0, but pytest limits to <1.0.0 and tox does not, so they disagree on the version to use.
+# This pin can be removed once pytest ships 6.2.5 which will remove the upper limit on the pluggy version.
+pluggy<1.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ argparse==1.4.0
     # via
     #   -r requirements/test.txt
     #   unittest2
-astroid==2.6.6
+astroid==2.7.3
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -60,7 +60,7 @@ coverage==5.5
     #   -r requirements/test.txt
     #   codecov
     #   pytest-cov
-cryptography==3.4.7
+cryptography==3.4.8
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -92,7 +92,7 @@ future==0.18.2
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-httpretty==1.1.3
+httpretty==1.1.4
     # via -r requirements/test.txt
 idna==3.2
     # via
@@ -148,13 +148,15 @@ pep517==0.11.0
     #   pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip-tools.txt
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
+    #   pylint
     #   virtualenv
 pluggy==0.13.1
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pytest
@@ -181,7 +183,7 @@ pyjwt[crypto]==2.1.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pylint==2.9.6
+pylint==2.10.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -206,7 +208,7 @@ pyparsing==2.4.7
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -265,7 +267,7 @@ sqlparse==0.4.1
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==3.3.0
+stevedore==3.4.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -285,7 +287,7 @@ tomli==1.2.1
     # via
     #   -r requirements/pip-tools.txt
     #   pep517
-tox==3.24.1
+tox==3.24.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -303,12 +305,12 @@ urllib3==1.26.6
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
-virtualenv==20.7.0
+virtualenv==20.7.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   tox
-wheel==0.36.2
+wheel==0.37.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -12,7 +12,7 @@ pip-tools==6.2.0
     # via -r requirements/pip-tools.in
 tomli==1.2.1
     # via pep517
-wheel==0.36.2
+wheel==0.37.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.36.2
+wheel==0.37.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.3
+pip==21.2.4
     # via -r requirements/pip.in
 setuptools==57.4.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 argparse==1.4.0
     # via unittest2
-astroid==2.6.6
+astroid==2.7.3
     # via
     #   pylint
     #   pylint-celery
@@ -39,7 +39,7 @@ coverage==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==3.4.7
+cryptography==3.4.8
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -63,7 +63,7 @@ filelock==3.0.12
     #   virtualenv
 future==0.18.2
     # via pyjwkest
-httpretty==1.1.3
+httpretty==1.1.4
     # via -r requirements/test.in
 idna==3.2
     # via
@@ -94,10 +94,13 @@ packaging==21.0
     #   tox
 pbr==5.6.0
     # via stevedore
-platformdirs==2.2.0
-    # via virtualenv
+platformdirs==2.3.0
+    # via
+    #   pylint
+    #   virtualenv
 pluggy==0.13.1
     # via
+    #   -c requirements/common_constraints.txt
     #   pytest
     #   tox
 py==1.10.0
@@ -118,7 +121,7 @@ pyjwt[crypto]==2.1.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pylint==2.9.6
+pylint==2.10.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -134,7 +137,7 @@ pylint-plugin-utils==0.6
     #   pylint-django
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   pytest-cov
     #   pytest-django
@@ -185,7 +188,7 @@ sqlparse==0.4.1
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==3.3.0
+stevedore==3.4.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
@@ -195,7 +198,7 @@ toml==0.10.2
     #   pytest
     #   pytest-cov
     #   tox
-tox==3.24.1
+tox==3.24.3
     # via -r requirements/test.in
 traceback2==1.4.0
     # via unittest2
@@ -205,7 +208,7 @@ urllib3==1.26.6
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.7.0
+virtualenv==20.7.2
     # via tox
 wrapt==1.12.1
     # via astroid


### PR DESCRIPTION
**Issue:** [BOM-2774](https://openedx.atlassian.net/browse/BOM-2774)

### Description
- https://github.com/edx/auth-backends/pull/125 upgraded the `pyjwt` package to the latest version in the repo.
- common_constraints has the constraint pyjwt<2.0.0 in them which conflicts with the latest version now required in the `base.in` so upgraded the condition to handle this constraint in the make upgrade step.

