### PR TITLE
fix: remove required reviewer from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,6 @@ Describe in a couple of sentences what this PR adds
 * **Author concerns:** List any concerns about this PR
 
 **Reviewers:**
-- [ ] @edx/arch-review
 - [ ] tag reviewer
 
 **Merge checklist:**


### PR DESCRIPTION
Remove `@edx/arch-review` from the list of required reviewers.

I added the PR template as part of adding a changelog 2 years ago,
and I don't see any reason to also have added a new review requirement,
namely `@edx/arch-review`. It is possible this was just copy/pasted.

Most contributors are already accustomed to asking owners for review
when and if there is any significant change that requires review. This
change simplifies the process for simple changes by not implying that
arch-review (which is not actually the owner anyway) needs to review.

**Description:**

Describe in a couple of sentences what this PR adds

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Additional Details**

* **Dependencies:**: List dependencies on other outstanding PRs, issues, etc.
* **Merge deadline:** List merge deadline (if any)
* **Testing instructions:** Provide non-trivial testing instructions
* **Author concerns:** List any concerns about this PR

**Reviewers:**
- [ ] @edx/arch-review
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
