### PR TITLE
fix: enhance get_user_if_exists pipeline function with debugging capabilities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,21 @@ Unreleased
 ----------
 
 
+[4.6.1] - 2025-07-25
+--------------------
+
+Added
+~~~~~
+
+* Added IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle to handle username mismatches in authentication pipeline.
+* Enhanced get_user_if_exists function with monitoring capabilities for debugging authentication conflicts.
+
+Fixed
+~~~~~
+
+* Fixed authentication issues where username mismatches between logged-in users and social auth details caused "user already exists" errors.
+* Improved user account conflict resolution in devstack and stage environments.
+
 [4.6.0] - 2025-06-18
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,15 +13,16 @@ Unreleased
 ----------
 
 
-[4.6.1] - 2025-07-25
+[4.6.1] - 2025-08-26
 --------------------
 
 Fixed
 ~~~~~
 
-* Fixed authentication issues where username mismatches between logged-in users and social auth details caused "user already exists" errors.
+* Fixed authentication issues where the social auth details username is not being respected as the user to be logged in in certain cases.
+  When the already logged-in user does not match the social auth details user, the pipeline should log in the new user, rather than leaving some other user logged in.
 
-  * Added temporary rollout toggle IGNORE_LOGGED_IN_USER_ON_MISMATCH to ensure the bug fix doesn't introduce any issues..
+  * Added temporary rollout toggle IGNORE_LOGGED_IN_USER_ON_MISMATCH to ensure the bug fix doesn't introduce any issues.
   * Enhanced get_user_if_exists function with monitoring capabilities for debugging authentication conflicts.
 
 [4.6.0] - 2025-06-18

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,17 +16,13 @@ Unreleased
 [4.6.1] - 2025-07-25
 --------------------
 
-Added
-~~~~~
-
-* Added IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle to handle username mismatches in authentication pipeline.
-* Enhanced get_user_if_exists function with monitoring capabilities for debugging authentication conflicts.
-
 Fixed
 ~~~~~
 
 * Fixed authentication issues where username mismatches between logged-in users and social auth details caused "user already exists" errors.
-* Improved user account conflict resolution in devstack and stage environments.
+
+  * Added temporary rollout toggle IGNORE_LOGGED_IN_USER_ON_MISMATCH to ensure the bug fix doesn't introduce any issues..
+  * Enhanced get_user_if_exists function with monitoring capabilities for debugging authentication conflicts.
 
 [4.6.0] - 2025-06-18
 --------------------

--- a/auth_backends/__init__.py
+++ b/auth_backends/__init__.py
@@ -3,4 +3,4 @@
  These package is designed to be used primarily with Open edX Django projects, but should be compatible with non-edX
  projects as well.
 """
-__version__ = '4.6.0'  # pragma: no cover
+__version__ = '4.6.1'  # pragma: no cover

--- a/auth_backends/backends.py
+++ b/auth_backends/backends.py
@@ -31,7 +31,6 @@ def _to_language(locale):
     return locale.replace('_', '-').lower()
 
 
-# pylint: disable=abstract-method
 class EdXOAuth2(BaseOAuth2):
     """
     IMPORTANT: The oauth2 application must have access to the ``user_id`` scope in order

--- a/auth_backends/pipeline.py
+++ b/auth_backends/pipeline.py
@@ -42,6 +42,11 @@ def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint
     """
     Return a User with the given username iff the User exists.
     """
+    # .. custom_attribute_name: get_user_if_exists.ignore_toggle_enabled
+    # .. custom_attribute_description: Tracks whether the IGNORE_LOGGED_IN_USER_ON_MISMATCH
+    #    toggle is enabled during this pipeline execution.
+    set_custom_attribute('get_user_if_exists.ignore_toggle_enabled', IGNORE_LOGGED_IN_USER_ON_MISMATCH.is_enabled())
+
     if user:
         # Check for username mismatch and toggle behavior
         details_username = details.get('username')
@@ -53,11 +58,6 @@ def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint
         #    the username in the social details and the user's actual username.
         #    True if usernames don't match, False if they match.
         set_custom_attribute('get_user_if_exists.username_mismatch', username_mismatch)
-
-        # .. custom_attribute_name: get_user_if_exists.ignore_toggle_enabled
-        # .. custom_attribute_description: Tracks whether the IGNORE_LOGGED_IN_USER_ON_MISMATCH
-        #    toggle is enabled during this pipeline execution.
-        set_custom_attribute('get_user_if_exists.ignore_toggle_enabled', IGNORE_LOGGED_IN_USER_ON_MISMATCH.is_enabled())
 
         if username_mismatch and IGNORE_LOGGED_IN_USER_ON_MISMATCH.is_enabled():
             logger.info(

--- a/auth_backends/pipeline.py
+++ b/auth_backends/pipeline.py
@@ -81,9 +81,7 @@ def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint
 
 
 def update_email(strategy, details, user=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
-    """
-    Update the user's email address using data from provider.
-    """
+    """Update the user's email address using data from provider."""
 
     if user:
         # Get usernames for comparison, using defensive coding

--- a/auth_backends/pipeline.py
+++ b/auth_backends/pipeline.py
@@ -54,7 +54,7 @@ def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint
 
         # .. custom_attribute_name: get_user_if_exists.has_details_username
         # .. custom_attribute_description: Tracks whether the details contain a username field.
-        #    True if username is present and not None, False if username is missing or None.
+        #    True if username is present, False if missing.
         set_custom_attribute('get_user_if_exists.has_details_username', bool(details_username))
 
         username_mismatch = details_username != user_username

--- a/auth_backends/pipeline.py
+++ b/auth_backends/pipeline.py
@@ -51,6 +51,12 @@ def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint
         # Check for username mismatch and toggle behavior
         details_username = details.get('username')
         user_username = getattr(user, 'username', None)
+
+        # .. custom_attribute_name: get_user_if_exists.has_details_username
+        # .. custom_attribute_description: Tracks whether the details contain a username field.
+        #    True if username is present and not None, False if username is missing or None.
+        set_custom_attribute('get_user_if_exists.has_details_username', bool(details_username))
+
         username_mismatch = details_username != user_username
 
         # .. custom_attribute_name: get_user_if_exists.username_mismatch

--- a/auth_backends/pipeline.py
+++ b/auth_backends/pipeline.py
@@ -22,25 +22,143 @@ User = get_user_model()
 # .. toggle_target_removal_date: 2025-08-18
 SKIP_UPDATE_EMAIL_ON_USERNAME_MISMATCH = SettingToggle("SKIP_UPDATE_EMAIL_ON_USERNAME_MISMATCH", default=False)
 
+# .. toggle_name: DEBUG_GET_USER_IF_EXISTS
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: Enables detailed debugging and monitoring for the get_user_if_exists pipeline function.
+#    When enabled (True), additional logging and custom attributes will be set to help debug
+#    user account conflicts and authentication issues.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2025-07-23
+# .. toggle_target_removal_date: 2025-09-23
+DEBUG_GET_USER_IF_EXISTS = SettingToggle("DEBUG_GET_USER_IF_EXISTS", default=False)
+
 
 # pylint: disable=unused-argument
 # The function parameters must be named exactly as they are below.
 # Do not change them to appease Pylint.
 def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
-    """Return a User with the given username iff the User exists."""
+    """Return a User with the given username iff the User exists.
+
+    Enhanced with debugging capabilities to track user account conflicts and authentication issues.
+    """
+    details_username = details.get('username')
+
+    # Set custom attributes for debugging
+    # .. custom_attribute_name: get_user_if_exists.details_username
+    # .. custom_attribute_description: Records the username provided in the social details
+    #    to help debug authentication and user lookup issues.
+    set_custom_attribute('get_user_if_exists.details_username', details_username)
+
+    # .. custom_attribute_name: get_user_if_exists.user_provided
+    # .. custom_attribute_description: Indicates whether a user object was already provided
+    #    to the pipeline function, which affects the lookup logic.
+    set_custom_attribute('get_user_if_exists.user_provided', user is not None)
+
+    # .. custom_attribute_name: get_user_if_exists.debug_enabled
+    # .. custom_attribute_description: Tracks whether the DEBUG_GET_USER_IF_EXISTS
+    #    toggle is enabled during this pipeline execution.
+    set_custom_attribute('get_user_if_exists.debug_enabled', DEBUG_GET_USER_IF_EXISTS.is_enabled())
+
     if user:
+        # User is already provided - this typically happens when user exists from previous pipeline steps
+        existing_username = getattr(user, 'username', None)
+
+        # .. custom_attribute_name: get_user_if_exists.existing_user_username
+        # .. custom_attribute_description: Records the username of the existing user object
+        #    when a user is already provided to the pipeline.
+        set_custom_attribute('get_user_if_exists.existing_user_username', existing_username)
+
+        # Check for username mismatch between provided user and details
+        username_mismatch = details_username != existing_username
+
+        # .. custom_attribute_name: get_user_if_exists.username_mismatch
+        # .. custom_attribute_description: Tracks whether there's a mismatch between
+        #    the username in details and the existing user's username.
+        set_custom_attribute('get_user_if_exists.username_mismatch', username_mismatch)
+
+        if DEBUG_GET_USER_IF_EXISTS.is_enabled() or username_mismatch:
+            logger.info(
+                "get_user_if_exists: User already provided. Username mismatch: %s. "
+                "Details username: %s, Existing user username: %s",
+                username_mismatch,
+                details_username,
+                existing_username
+            )
+
+        if username_mismatch:
+            logger.warning(
+                "Username mismatch in get_user_if_exists. Details username: %s, "
+                "Existing user username: %s. This may indicate an authentication issue.",
+                details_username,
+                existing_username
+            )
+
         return {'is_new': False}
+
+    # No user provided, attempt to find user by username from details
+    if not details_username:
+        logger.warning("get_user_if_exists: No username provided in details")
+        # .. custom_attribute_name: get_user_if_exists.no_username_in_details
+        # .. custom_attribute_description: Indicates that no username was provided in the details,
+        #    which may indicate an issue with the authentication provider.
+        set_custom_attribute('get_user_if_exists.no_username_in_details', True)
+        return {}
+
     try:
-        username = details.get('username')
+        found_user = User.objects.get(username=details_username)
+
+        # .. custom_attribute_name: get_user_if_exists.user_found
+        # .. custom_attribute_description: Indicates that a user was successfully found
+        #    by username lookup in the database.
+        set_custom_attribute('get_user_if_exists.user_found', True)
+
+        # .. custom_attribute_name: get_user_if_exists.found_user_id
+        # .. custom_attribute_description: Records the ID of the user found by username lookup
+        #    to help track user account conflicts.
+        set_custom_attribute('get_user_if_exists.found_user_id', found_user.id)
+
+        if DEBUG_GET_USER_IF_EXISTS.is_enabled():
+            logger.info(
+                "get_user_if_exists: Found existing user with username '%s' (ID: %s)",
+                details_username,
+                found_user.id
+            )
 
         # Return the user if it exists
         return {
             'is_new': False,
-            'user': User.objects.get(username=username)
+            'user': found_user
         }
     except User.DoesNotExist:
-        # Fall to the default return value
-        pass
+        # .. custom_attribute_name: get_user_if_exists.user_found
+        # .. custom_attribute_description: Indicates that no user was found
+        #    by username lookup in the database.
+        set_custom_attribute('get_user_if_exists.user_found', False)
+
+        if DEBUG_GET_USER_IF_EXISTS.is_enabled():
+            logger.info(
+                "get_user_if_exists: No user found with username '%s'",
+                details_username
+            )
+
+    except Exception as e:
+        # Handle any unexpected errors during user lookup
+        logger.error(
+            "get_user_if_exists: Unexpected error during user lookup for username '%s': %s",
+            details_username,
+            str(e)
+        )
+
+        # .. custom_attribute_name: get_user_if_exists.lookup_error
+        # .. custom_attribute_description: Indicates that an unexpected error occurred
+        #    during user lookup, which may indicate database or system issues.
+        set_custom_attribute('get_user_if_exists.lookup_error', True)
+
+        # .. custom_attribute_name: get_user_if_exists.error_message
+        # .. custom_attribute_description: Records the error message when an unexpected
+        #    error occurs during user lookup.
+        set_custom_attribute('get_user_if_exists.error_message', str(e))
 
     # Nothing to return since we don't have a user
     return {}

--- a/auth_backends/pipeline.py
+++ b/auth_backends/pipeline.py
@@ -61,7 +61,7 @@ def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint
 
         if username_mismatch and IGNORE_LOGGED_IN_USER_ON_MISMATCH.is_enabled():
             logger.info(
-                "Username mismatch detected. Details: %s, User: %s. Ignoring logged-in user.",
+                "Username mismatch detected. Username from Details: %s, Username from User: %s.",
                 details_username, user_username
             )
         else:

--- a/auth_backends/pipeline.py
+++ b/auth_backends/pipeline.py
@@ -22,150 +22,68 @@ User = get_user_model()
 # .. toggle_target_removal_date: 2025-08-18
 SKIP_UPDATE_EMAIL_ON_USERNAME_MISMATCH = SettingToggle("SKIP_UPDATE_EMAIL_ON_USERNAME_MISMATCH", default=False)
 
-# .. toggle_name: DEBUG_GET_USER_IF_EXISTS
+# .. toggle_name: IGNORE_LOGGED_IN_USER_ON_MISMATCH
 # .. toggle_implementation: SettingToggle
-# .. toggle_default: False
-# .. toggle_description: Enables detailed debugging and monitoring for the get_user_if_exists pipeline function.
-#    When enabled (True), additional logging and custom attributes will be set to help debug
-#    user account conflicts and authentication issues.
+# .. toggle_default: True
+# .. toggle_description: Controls behavior when there's a username mismatch between the logged-in user
+#    and social auth details. When enabled (True), ignores the logged-in user and proceeds with
+#    user lookup from social auth details. When disabled (False), proceeds with the logged-in user
+#    despite the mismatch. This toggle is for temporary rollout only to ensure we don't create bugs.
 # .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2025-07-23
-# .. toggle_target_removal_date: 2025-09-23
-DEBUG_GET_USER_IF_EXISTS = SettingToggle("DEBUG_GET_USER_IF_EXISTS", default=False)
+# .. toggle_creation_date: 2025-07-25
+# .. toggle_target_removal_date: 2025-09-25
+IGNORE_LOGGED_IN_USER_ON_MISMATCH = SettingToggle("IGNORE_LOGGED_IN_USER_ON_MISMATCH", default=True)
 
 
 # pylint: disable=unused-argument
 # The function parameters must be named exactly as they are below.
 # Do not change them to appease Pylint.
 def get_user_if_exists(strategy, details, user=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
-    """Return a User with the given username iff the User exists.
-
-    Enhanced with debugging capabilities to track user account conflicts and authentication issues.
     """
-    details_username = details.get('username')
-
-    # Set custom attributes for debugging
-    # .. custom_attribute_name: get_user_if_exists.details_username
-    # .. custom_attribute_description: Records the username provided in the social details
-    #    to help debug authentication and user lookup issues.
-    set_custom_attribute('get_user_if_exists.details_username', details_username)
-
-    # .. custom_attribute_name: get_user_if_exists.user_provided
-    # .. custom_attribute_description: Indicates whether a user object was already provided
-    #    to the pipeline function, which affects the lookup logic.
-    set_custom_attribute('get_user_if_exists.user_provided', user is not None)
-
-    # .. custom_attribute_name: get_user_if_exists.debug_enabled
-    # .. custom_attribute_description: Tracks whether the DEBUG_GET_USER_IF_EXISTS
-    #    toggle is enabled during this pipeline execution.
-    set_custom_attribute('get_user_if_exists.debug_enabled', DEBUG_GET_USER_IF_EXISTS.is_enabled())
-
+    Return a User with the given username iff the User exists.
+    """
     if user:
-        # User is already provided - this typically happens when user exists from previous pipeline steps
-        existing_username = getattr(user, 'username', None)
-
-        # .. custom_attribute_name: get_user_if_exists.existing_user_username
-        # .. custom_attribute_description: Records the username of the existing user object
-        #    when a user is already provided to the pipeline.
-        set_custom_attribute('get_user_if_exists.existing_user_username', existing_username)
-
-        # Check for username mismatch between provided user and details
-        username_mismatch = details_username != existing_username
+        # Check for username mismatch and toggle behavior
+        details_username = details.get('username')
+        user_username = getattr(user, 'username', None)
+        username_mismatch = details_username != user_username
 
         # .. custom_attribute_name: get_user_if_exists.username_mismatch
         # .. custom_attribute_description: Tracks whether there's a mismatch between
-        #    the username in details and the existing user's username.
+        #    the username in the social details and the user's actual username.
+        #    True if usernames don't match, False if they match.
         set_custom_attribute('get_user_if_exists.username_mismatch', username_mismatch)
 
-        if DEBUG_GET_USER_IF_EXISTS.is_enabled() or username_mismatch:
+        # .. custom_attribute_name: get_user_if_exists.ignore_toggle_enabled
+        # .. custom_attribute_description: Tracks whether the IGNORE_LOGGED_IN_USER_ON_MISMATCH
+        #    toggle is enabled during this pipeline execution.
+        set_custom_attribute('get_user_if_exists.ignore_toggle_enabled', IGNORE_LOGGED_IN_USER_ON_MISMATCH.is_enabled())
+
+        if username_mismatch and IGNORE_LOGGED_IN_USER_ON_MISMATCH.is_enabled():
             logger.info(
-                "get_user_if_exists: User already provided. Username mismatch: %s. "
-                "Details username: %s, Existing user username: %s",
-                username_mismatch,
-                details_username,
-                existing_username
+                "Username mismatch detected. Details: %s, User: %s. Ignoring logged-in user.",
+                details_username, user_username
             )
-
-        if username_mismatch:
-            logger.warning(
-                "Username mismatch in get_user_if_exists. Details username: %s, "
-                "Existing user username: %s. This may indicate an authentication issue.",
-                details_username,
-                existing_username
-            )
-
-        return {'is_new': False}
-
-    # No user provided, attempt to find user by username from details
-    if not details_username:
-        logger.warning("get_user_if_exists: No username provided in details")
-        # .. custom_attribute_name: get_user_if_exists.no_username_in_details
-        # .. custom_attribute_description: Indicates that no username was provided in the details,
-        #    which may indicate an issue with the authentication provider.
-        set_custom_attribute('get_user_if_exists.no_username_in_details', True)
-        return {}
+        else:
+            return {'is_new': False}
 
     try:
-        found_user = User.objects.get(username=details_username)
+        username = details.get('username')
 
-        # .. custom_attribute_name: get_user_if_exists.user_found
-        # .. custom_attribute_description: Indicates that a user was successfully found
-        #    by username lookup in the database.
-        set_custom_attribute('get_user_if_exists.user_found', True)
-
-        # .. custom_attribute_name: get_user_if_exists.found_user_id
-        # .. custom_attribute_description: Records the ID of the user found by username lookup
-        #    to help track user account conflicts.
-        set_custom_attribute('get_user_if_exists.found_user_id', found_user.id)
-
-        if DEBUG_GET_USER_IF_EXISTS.is_enabled():
-            logger.info(
-                "get_user_if_exists: Found existing user with username '%s' (ID: %s)",
-                details_username,
-                found_user.id
-            )
-
-        # Return the user if it exists
         return {
             'is_new': False,
-            'user': found_user
+            'user': User.objects.get(username=username)
         }
     except User.DoesNotExist:
-        # .. custom_attribute_name: get_user_if_exists.user_found
-        # .. custom_attribute_description: Indicates that no user was found
-        #    by username lookup in the database.
-        set_custom_attribute('get_user_if_exists.user_found', False)
+        pass
 
-        if DEBUG_GET_USER_IF_EXISTS.is_enabled():
-            logger.info(
-                "get_user_if_exists: No user found with username '%s'",
-                details_username
-            )
-
-    except Exception as e:
-        # Handle any unexpected errors during user lookup
-        logger.error(
-            "get_user_if_exists: Unexpected error during user lookup for username '%s': %s",
-            details_username,
-            str(e)
-        )
-
-        # .. custom_attribute_name: get_user_if_exists.lookup_error
-        # .. custom_attribute_description: Indicates that an unexpected error occurred
-        #    during user lookup, which may indicate database or system issues.
-        set_custom_attribute('get_user_if_exists.lookup_error', True)
-
-        # .. custom_attribute_name: get_user_if_exists.error_message
-        # .. custom_attribute_description: Records the error message when an unexpected
-        #    error occurs during user lookup.
-        set_custom_attribute('get_user_if_exists.error_message', str(e))
-
-    # Nothing to return since we don't have a user
     return {}
 
 
 def update_email(strategy, details, user=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
-    """Update the user's email address using data from provider."""
+    """
+    Update the user's email address using data from provider.
+    """
 
     if user:
         # Get usernames for comparison, using defensive coding

--- a/auth_backends/tests/test_pipeline.py
+++ b/auth_backends/tests/test_pipeline.py
@@ -22,7 +22,8 @@ class GetUserIfExistsPipelineTests(TestCase):
         self.username = 'edx'
         self.details = {'username': self.username}
 
-    @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle
+    # Test behavior when no user exists in database with and without toggle
+    @ddt.data(True, False)
     def test_no_user_exists(self, setting_value):
         """Returns empty dict if no user exists regardless of setting."""
         with override_settings(IGNORE_LOGGED_IN_USER_ON_MISMATCH=setting_value):
@@ -30,7 +31,8 @@ class GetUserIfExistsPipelineTests(TestCase):
             expected = {}
             self.assertDictEqual(actual, expected)
 
-    @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle
+    # Test behavior when user exists but no current user with and without toggle
+    @ddt.data(True, False)
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')
     def test_get_user_if_exists_no_current_user(self, toggle_enabled, mock_set_attribute, mock_logger):
@@ -45,7 +47,8 @@ class GetUserIfExistsPipelineTests(TestCase):
             mock_set_attribute.assert_any_call('get_user_if_exists.ignore_toggle_enabled', toggle_enabled)
             mock_logger.info.assert_not_called()
 
-    @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle
+    # Test behavior when usernames match with and without toggle
+    @ddt.data(True, False)
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')
     def test_get_user_if_exists_username_match(self, toggle_enabled, mock_set_attribute, mock_logger):
@@ -64,49 +67,60 @@ class GetUserIfExistsPipelineTests(TestCase):
             ], any_order=True)
             mock_logger.info.assert_not_called()
 
-    @ddt.data(
-        (True, True),   # toggle enabled, target exists
-        (True, False),  # toggle enabled, target missing
-        (False, True),  # toggle disabled, target exists
-        (False, False)  # toggle disabled, target missing
-    )
-    @ddt.unpack
+    # Test username mismatch when target user exists with and without toggle
+    @ddt.data(True, False)
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')
-    def test_get_user_if_exists_username_mismatch(self, toggle_enabled, target_exists, mock_set_attribute, mock_logger):
-        """Test username mismatch scenarios with different toggle states and target user presence."""
+    def test_get_user_if_exists_username_mismatch_with_target(self, toggle_enabled, mock_set_attribute, mock_logger):
+        """Toggle enabled: return target user. Toggle disabled: return empty dict."""
         with override_settings(IGNORE_LOGGED_IN_USER_ON_MISMATCH=toggle_enabled):
             user = User.objects.create(username='existing_user')
-            target_user = None
+            user_map = {}
 
-            if target_exists:
-                target_user = User.objects.create(username='different_user')
-                details = {'username': 'different_user'}
-                details_username = 'different_user'
-            else:
-                details = {'username': 'nonexistent_user'}
-                details_username = 'nonexistent_user'
+            target_user = User.objects.create(username='different_user')
+            user_map['target_user'] = target_user
+
+            details = {'username': 'different_user'}
 
             actual = get_user_if_exists(None, details, user=user)
 
-            if toggle_enabled and target_exists:
-                # Toggle enabled and target exists: return target user
-                expected = {'is_new': False, 'user': target_user}
+            if toggle_enabled:
+                expected = {'is_new': False, 'user': user_map['target_user']}
                 mock_logger.info.assert_called_with(
                     "Username mismatch detected. Username from Details: %s, Username from User: %s.",
-                    details_username,
-                    'existing_user'
-                )
-            elif toggle_enabled and not target_exists:
-                # Toggle enabled and no target: return empty dict with logging
-                expected = {}
-                mock_logger.info.assert_called_with(
-                    "Username mismatch detected. Username from Details: %s, Username from User: %s.",
-                    details_username,
+                    'different_user',
                     'existing_user'
                 )
             else:
-                # Toggle disabled: return empty dict without logging
+                expected = {'is_new': False}
+                mock_logger.info.assert_not_called()
+
+            self.assertDictEqual(actual, expected)
+            mock_set_attribute.assert_has_calls([
+                call('get_user_if_exists.ignore_toggle_enabled', toggle_enabled),
+                call('get_user_if_exists.username_mismatch', True)
+            ], any_order=True)
+
+    # Test username mismatch when target user does not exist with and without toggle
+    @ddt.data(True, False)
+    @patch('auth_backends.pipeline.logger')
+    @patch('auth_backends.pipeline.set_custom_attribute')
+    def test_get_user_if_exists_username_mismatch_no_target(self, toggle_enabled, mock_set_attribute, mock_logger):
+        """Toggle enabled: log warning and return empty dict. Toggle disabled: return empty dict without logging."""
+        with override_settings(IGNORE_LOGGED_IN_USER_ON_MISMATCH=toggle_enabled):
+            user = User.objects.create(username='existing_user')
+            details = {'username': 'nonexistent_user'}
+
+            actual = get_user_if_exists(None, details, user=user)
+
+            if toggle_enabled:
+                expected = {}
+                mock_logger.info.assert_called_with(
+                    "Username mismatch detected. Username from Details: %s, Username from User: %s.",
+                    'nonexistent_user',
+                    'existing_user'
+                )
+            else:
                 expected = {'is_new': False}
                 mock_logger.info.assert_not_called()
 

--- a/auth_backends/tests/test_pipeline.py
+++ b/auth_backends/tests/test_pipeline.py
@@ -22,14 +22,15 @@ class GetUserIfExistsPipelineTests(TestCase):
         self.username = 'edx'
         self.details = {'username': self.username}
 
-    @ddt.data(True, False)
+    @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle
     def test_no_user_exists(self, setting_value):
         """Returns empty dict if no user exists regardless of setting."""
         with override_settings(IGNORE_LOGGED_IN_USER_ON_MISMATCH=setting_value):
             actual = get_user_if_exists(None, self.details)
-            self.assertDictEqual(actual, {})
+            expected = {}
+            self.assertDictEqual(actual, expected)
 
-    @ddt.data(True, False)
+    @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')
     def test_get_user_if_exists_no_current_user(self, toggle_enabled, mock_set_attribute, mock_logger):
@@ -44,7 +45,7 @@ class GetUserIfExistsPipelineTests(TestCase):
             mock_set_attribute.assert_any_call('get_user_if_exists.ignore_toggle_enabled', toggle_enabled)
             mock_logger.info.assert_not_called()
 
-    @ddt.data(True, False)
+    @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')
     def test_get_user_if_exists_username_match(self, toggle_enabled, mock_set_attribute, mock_logger):
@@ -54,15 +55,16 @@ class GetUserIfExistsPipelineTests(TestCase):
             details = {'username': 'existing_user'}
 
             actual = get_user_if_exists(None, details, user=user)
+            expected = {'is_new': False}
 
-            self.assertDictEqual(actual, {'is_new': False})
+            self.assertDictEqual(actual, expected)
             mock_set_attribute.assert_has_calls([
                 call('get_user_if_exists.ignore_toggle_enabled', toggle_enabled),
                 call('get_user_if_exists.username_mismatch', False)
             ], any_order=True)
             mock_logger.info.assert_not_called()
 
-    @ddt.data(True, False)
+    @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')
     def test_get_user_if_exists_username_mismatch_with_target(self, toggle_enabled, mock_set_attribute, mock_logger):
@@ -91,7 +93,7 @@ class GetUserIfExistsPipelineTests(TestCase):
                 call('get_user_if_exists.username_mismatch', True)
             ], any_order=True)
 
-    @ddt.data(True, False)
+    @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')
     def test_get_user_if_exists_username_mismatch_no_target(self, toggle_enabled, mock_set_attribute, mock_logger):

--- a/auth_backends/tests/test_pipeline.py
+++ b/auth_backends/tests/test_pipeline.py
@@ -81,7 +81,7 @@ class GetUserIfExistsPipelineTests(TestCase):
         mock_set_attribute.assert_any_call('get_user_if_exists.ignore_toggle_enabled', True)
 
         mock_logger.info.assert_called_once_with(
-            "Username mismatch detected. Details: %s, User: %s. Ignoring logged-in user.",
+            "Username mismatch detected. Username from Details: %s, Username from User: %s.",
             'different_user',
             'existing_user'
         )
@@ -123,7 +123,7 @@ class GetUserIfExistsPipelineTests(TestCase):
         mock_set_attribute.assert_any_call('get_user_if_exists.ignore_toggle_enabled', True)
 
         mock_logger.info.assert_called_once_with(
-            "Username mismatch detected. Details: %s, User: %s. Ignoring logged-in user.",
+            "Username mismatch detected. Username from Details: %s, Username from User: %s.",
             'nonexistent_user',
             'existing_user'
         )

--- a/auth_backends/tests/test_pipeline.py
+++ b/auth_backends/tests/test_pipeline.py
@@ -22,7 +22,7 @@ class GetUserIfExistsPipelineTests(TestCase):
         self.username = 'edx'
         self.details = {'username': self.username}
 
-    # Test behavior when no user exists in database with and without toggle
+    # Test no user exists in database with and without toggle
     @ddt.data(True, False)
     def test_no_user_exists(self, setting_value):
         """Returns empty dict if no user exists regardless of setting."""
@@ -31,7 +31,7 @@ class GetUserIfExistsPipelineTests(TestCase):
             expected = {}
             self.assertDictEqual(actual, expected)
 
-    # Test behavior when user exists but no current user with and without toggle
+    # Test user exists but no current user with and without toggle
     @ddt.data(True, False)
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')
@@ -47,7 +47,7 @@ class GetUserIfExistsPipelineTests(TestCase):
             mock_set_attribute.assert_any_call('get_user_if_exists.ignore_toggle_enabled', toggle_enabled)
             mock_logger.info.assert_not_called()
 
-    # Test behavior when usernames match with and without toggle
+    # Test usernames match with and without toggle
     @ddt.data(True, False)
     @patch('auth_backends.pipeline.logger')
     @patch('auth_backends.pipeline.set_custom_attribute')

--- a/auth_backends/tests/test_pipeline.py
+++ b/auth_backends/tests/test_pipeline.py
@@ -22,7 +22,7 @@ class GetUserIfExistsPipelineTests(TestCase):
         self.details_for_existing_user = {'username': 'existing_user'}
         self.details_for_non_existing_user = {'username': 'non_existing_user'}
         self.details_for_different_user = {'username': 'different_user'}
-        self.user = User.objects.create(**self.details_for_existing_user)
+        self.existing_user = User.objects.create(**self.details_for_existing_user)
 
     @ddt.data(True, False)  # test IGNORE_LOGGED_IN_USER_ON_MISMATCH toggle enabled/disabled
     def test_no_user_exists(self, toggle_enabled):
@@ -38,8 +38,7 @@ class GetUserIfExistsPipelineTests(TestCase):
     def test_get_user_if_exists_no_current_user(self, toggle_enabled, mock_set_attribute, mock_logger):
         """Returns details user when it can be found and there is no current user, regardless of toggle setting"""
         with override_settings(IGNORE_LOGGED_IN_USER_ON_MISMATCH=toggle_enabled):
-            existing_user = self.user
-
+            existing_user = self.existing_user
             actual = get_user_if_exists(None, self.details_for_existing_user, user=None)
 
             expected = {'is_new': False, 'user': existing_user}
@@ -53,14 +52,14 @@ class GetUserIfExistsPipelineTests(TestCase):
     def test_get_user_if_exists_username_match(self, toggle_enabled, mock_set_attribute, mock_logger):
         """Returns dict without user element when current user matches details username, regardless of toggle."""
         with override_settings(IGNORE_LOGGED_IN_USER_ON_MISMATCH=toggle_enabled):
-            existing_user = self.user
-
+            existing_user = self.existing_user
             actual = get_user_if_exists(None, self.details_for_existing_user, user=existing_user)
             expected = {'is_new': False}
 
             self.assertDictEqual(actual, expected)
             mock_set_attribute.assert_has_calls([
                 call('get_user_if_exists.ignore_toggle_enabled', toggle_enabled),
+                call('get_user_if_exists.has_details_username', True),
                 call('get_user_if_exists.username_mismatch', False)
             ], any_order=True)
             mock_logger.info.assert_not_called()
@@ -73,7 +72,7 @@ class GetUserIfExistsPipelineTests(TestCase):
     ):
         """Toggle enabled: return found details user. Toggle disabled: return dict without user element."""
         with override_settings(IGNORE_LOGGED_IN_USER_ON_MISMATCH=toggle_enabled):
-            existing_user = self.user
+            existing_user = self.existing_user
             different_user = User.objects.create(**self.details_for_different_user)
 
             actual = get_user_if_exists(None, self.details_for_different_user, user=existing_user)
@@ -92,6 +91,7 @@ class GetUserIfExistsPipelineTests(TestCase):
             self.assertDictEqual(actual, expected)
             mock_set_attribute.assert_has_calls([
                 call('get_user_if_exists.ignore_toggle_enabled', toggle_enabled),
+                call('get_user_if_exists.has_details_username', True),
                 call('get_user_if_exists.username_mismatch', True)
             ], any_order=True)
 
@@ -103,7 +103,7 @@ class GetUserIfExistsPipelineTests(TestCase):
     ):
         """Toggle enabled: return empty dict. Toggle disabled: return dict without user element."""
         with override_settings(IGNORE_LOGGED_IN_USER_ON_MISMATCH=toggle_enabled):
-            existing_user = self.user
+            existing_user = self.existing_user
 
             actual = get_user_if_exists(None, self.details_for_non_existing_user, user=existing_user)
 
@@ -121,6 +121,7 @@ class GetUserIfExistsPipelineTests(TestCase):
             self.assertDictEqual(actual, expected)
             mock_set_attribute.assert_has_calls([
                 call('get_user_if_exists.ignore_toggle_enabled', toggle_enabled),
+                call('get_user_if_exists.has_details_username', True),
                 call('get_user_if_exists.username_mismatch', True)
             ], any_order=True)
 

--- a/auth_backends/tests/test_pipeline.py
+++ b/auth_backends/tests/test_pipeline.py
@@ -23,7 +23,9 @@ class GetUserIfExistsPipelineTests(TestCase):
     @patch('auth_backends.pipeline.set_custom_attribute')
     @patch('auth_backends.pipeline.IGNORE_LOGGED_IN_USER_ON_MISMATCH.is_enabled')
     def test_no_user_exists(self, mock_toggle, mock_set_attribute):
-        """ Verify an empty dict is returned if no user exists. """
+        """
+        Verify an empty dict is returned if no user exists.
+        """
         mock_toggle.return_value = True
 
         actual = get_user_if_exists(None, self.details)

--- a/auth_backends/tests/test_pipeline.py
+++ b/auth_backends/tests/test_pipeline.py
@@ -94,7 +94,6 @@ class GetUserIfExistsPipelineTests(TestCase):
         )
 
     @patch('auth_backends.pipeline.logger')
-    @patch('auth_backends.pipeline.set_custom_attribute')
     @patch('auth_backends.pipeline.DEBUG_GET_USER_IF_EXISTS.is_enabled')
     def test_debug_enabled_with_existing_user(self, mock_debug_toggle, mock_logger):
         """ Verify debug logging when DEBUG_GET_USER_IF_EXISTS toggle is enabled. """
@@ -112,7 +111,6 @@ class GetUserIfExistsPipelineTests(TestCase):
         )
 
     @patch('auth_backends.pipeline.logger')
-    @patch('auth_backends.pipeline.set_custom_attribute')
     @patch('auth_backends.pipeline.DEBUG_GET_USER_IF_EXISTS.is_enabled')
     def test_debug_enabled_no_user_found(self, mock_debug_toggle, mock_logger):
         """ Verify debug logging when no user is found and debug is enabled. """
@@ -169,7 +167,6 @@ class GetUserIfExistsPipelineTests(TestCase):
         )
 
     @patch('auth_backends.pipeline.logger')
-    @patch('auth_backends.pipeline.set_custom_attribute')
     @patch('auth_backends.pipeline.DEBUG_GET_USER_IF_EXISTS.is_enabled')
     def test_debug_enabled_with_username_mismatch(self, mock_debug_toggle, mock_logger):
         """ Verify debug and warning logging when username mismatch occurs with debug enabled. """

--- a/auth_backends/tests/test_pipeline.py
+++ b/auth_backends/tests/test_pipeline.py
@@ -34,19 +34,19 @@ class GetUserIfExistsPipelineTests(TestCase):
     @ddt.data(
         # (test_config, expected_result)
         ({'setting': True, 'user_provided': False, 'username_match': True, 'target_exists': True},
-         {'is_new': False, 'user': 'found_user'}),
+         {'is_new': False, 'user': 'found_user'}),  # setting=True, no current user
         ({'setting': False, 'user_provided': False, 'username_match': True, 'target_exists': True},
-         {'is_new': False, 'user': 'found_user'}),
+         {'is_new': False, 'user': 'found_user'}),  # setting=False, no current user
         ({'setting': True, 'user_provided': True, 'username_match': True, 'target_exists': True},
-         {'is_new': False}),
+         {'is_new': False}),  # setting=True, usernames match
         ({'setting': False, 'user_provided': True, 'username_match': True, 'target_exists': True},
-         {'is_new': False}),
+         {'is_new': False}),  # setting=False, usernames match
         ({'setting': True, 'user_provided': True, 'username_match': False, 'target_exists': True},
-         {'is_new': False, 'user': 'target_user'}),
+         {'is_new': False, 'user': 'target_user'}),  # setting=True, mismatch with target
         ({'setting': False, 'user_provided': True, 'username_match': False, 'target_exists': True},
-         {'is_new': False}),
+         {'is_new': False}),  # setting=False, mismatch with target
         ({'setting': True, 'user_provided': True, 'username_match': False, 'target_exists': False},
-         {}),
+         {}),  # setting=True, mismatch no target
     )
     @ddt.unpack
     @patch('auth_backends.pipeline.logger')

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -13,5 +13,6 @@ pytest-cov
 pytest-django
 responses
 tox
+typing_extensions
 unittest2
 edx-django-release-util   # Contains the reserved keyword check

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,6 +4,7 @@
 -r base.txt                # Core dependencies
 
 coverage
+ddt                         # for running multiple test cases with multiple input
 edx-lint
 httpretty
 pycodestyle

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,15 +4,15 @@
 -r base.txt                # Core dependencies
 
 coverage
-ddt                         # for running multiple test cases with multiple input
+ddt                        # for running multiple test cases with multiple input
 edx-lint
 httpretty
 pycodestyle
-pycryptodomex                   # used for crypto tests
+pycryptodomex              # used for crypto tests
 pytest-cov
 pytest-django
-responses                    # required by ddt
+responses                  # required by ddt
 tox
-typing_extensions
+typing_extensions          # required by ddt
 unittest2
-edx-django-release-util   # Contains the reserved keyword check
+edx-django-release-util    # Contains the reserved keyword check

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,6 +11,7 @@ pycodestyle
 pycryptodomex                   # used for crypto tests
 pytest-cov
 pytest-django
+responses
 tox
 unittest2
 edx-django-release-util   # Contains the reserved keyword check

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,7 +11,7 @@ pycodestyle
 pycryptodomex                   # used for crypto tests
 pytest-cov
 pytest-django
-responses
+responses                    # required by ddt
 tox
 typing_extensions
 unittest2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,15 +6,15 @@
 #
 argparse==1.4.0
     # via unittest2
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==3.3.9
+astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
-certifi==2025.1.31
+certifi==2025.7.14
     # via
     #   -r requirements/base.txt
     #   requests
@@ -22,28 +22,36 @@ cffi==1.17.1
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.4.1
+    #   pynacl
+charset-normalizer==3.4.2
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.8
+click==8.2.1
     # via
+    #   -r requirements/base.txt
     #   click-log
     #   code-annotations
+    #   edx-django-utils
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
 code-annotations==2.3.0
-    # via edx-lint
-coverage[toml]==7.8.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-lint
+    #   edx-toggles
+coverage[toml]==7.10.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==44.0.2
+cryptography==45.0.5
     # via
     #   -r requirements/base.txt
     #   pyjwt
     #   social-auth-core
+ddt==1.7.2
+    # via -r requirements/test.in
 defusedxml==0.7.1
     # via
     #   -r requirements/base.txt
@@ -51,17 +59,37 @@ defusedxml==0.7.1
     #   social-auth-core
 dill==0.4.0
     # via pylint
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
+    #   django-crum
+    #   django-waffle
     #   edx-django-release-util
+    #   edx-django-utils
+    #   edx-toggles
     #   social-auth-app-django
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-toggles
+django-waffle==5.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-toggles
 edx-django-release-util==1.5.0
     # via -r requirements/test.in
+edx-django-utils==8.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-toggles
 edx-lint==5.6.0
     # via -r requirements/test.in
+edx-toggles==5.4.1
+    # via -r requirements/base.txt
 filelock==3.18.0
     # via
     #   tox
@@ -77,14 +105,18 @@ iniconfig==2.1.0
 isort==6.0.1
     # via pylint
 jinja2==3.1.6
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 linecache2==1.0.0
     # via traceback2
 markupsafe==3.0.2
-    # via jinja2
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
 mccabe==0.7.0
     # via pylint
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   -r requirements/base.txt
     #   requests-oauthlib
@@ -94,30 +126,39 @@ packaging==25.0
     #   pytest
     #   tox
 pbr==6.1.1
-    # via stevedore
-platformdirs==4.3.7
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
+platformdirs==4.3.8
     # via
     #   pylint
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   pytest
+    #   pytest-cov
     #   tox
+psutil==7.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
 py==1.11.0
     # via tox
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/test.in
 pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.22.0
+pycryptodomex==3.23.0
     # via -r requirements/test.in
+pygments==2.19.2
+    # via pytest
 pyjwt[crypto]==2.10.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   edx-lint
     #   pylint-celery
@@ -127,29 +168,36 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.6.1
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pytest==8.3.5
+pynacl==1.5.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+pytest==8.4.1
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.1.1
+pytest-cov==6.2.1
     # via -r requirements/test.in
 pytest-django==4.11.1
     # via -r requirements/test.in
 python-slugify==8.0.4
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
 pyyaml==6.0.2
     # via
+    #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-release-util
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements/base.txt
     #   requests-oauthlib
@@ -167,7 +215,7 @@ six==1.17.0
     #   unittest2
 social-auth-app-django==5.4.3
     # via -r requirements/base.txt
-social-auth-core==4.5.6
+social-auth-core==4.7.0
     # via
     #   -r requirements/base.txt
     #   social-auth-app-django
@@ -176,10 +224,15 @@ sqlparse==0.5.3
     #   -r requirements/base.txt
     #   django
 stevedore==5.4.1
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-django-utils
 text-unidecode==1.3
-    # via python-slugify
-tomlkit==0.13.2
+    # via
+    #   -r requirements/base.txt
+    #   python-slugify
+tomlkit==0.13.3
     # via pylint
 tox==3.28.0
     # via
@@ -189,12 +242,11 @@ traceback2==1.4.0
     # via unittest2
 unittest2==1.1.0
     # via -r requirements/test.in
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.30.0
+virtualenv==20.32.0
     # via tox
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -244,6 +244,8 @@ tox==3.28.0
     #   -r requirements/test.in
 traceback2==1.4.0
     # via unittest2
+typing-extensions==4.14.1
+    # via -r requirements/test.in
 unittest2==1.1.0
     # via -r requirements/test.in
 urllib3==2.5.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -197,15 +197,19 @@ pyyaml==6.0.2
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-release-util
+    #   responses
 requests==2.32.4
     # via
     #   -r requirements/base.txt
     #   requests-oauthlib
+    #   responses
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
+responses==0.25.7
+    # via -r requirements/test.in
 six==1.17.0
     # via
     #   -r requirements/base.txt
@@ -246,6 +250,7 @@ urllib3==2.5.0
     # via
     #   -r requirements/base.txt
     #   requests
+    #   responses
 virtualenv==20.32.0
     # via tox
 


### PR DESCRIPTION
### Description:

The `get_user_if_exists` function lacks visibility into authentication failures. We can't debug why "user already exists" errors happen in devstack but not in stage.

### Solution:

- **Added comprehensive debugging** with new toggle `IGNORE_LOGGED_IN_USER_ON_MISMATCH`.

- **Added custom attributes** to track authentication flow and detect issues:

          - Username mismatches between details and existing users.
          - User lookup success/failure states.
          - Database errors during user retrieval.

- **Improved logging** with detailed info and warning messages.

- **Removed unnecessary** `pass` statement for cleaner code.

### JIRA Ticket:

[BOMS-3](https://2u-internal.atlassian.net/browse/BOMS-3)

### Reference PR:

[PR](https://github.com/openedx/auth-backends/pull/382)

### Reference pr for testing legacy `get_user_if_exists` code with current test_file:
https://github.com/openedx/auth-backends/pull/395 
